### PR TITLE
feat(global): RFC 7807 ProblemDetail 기반 공통 에러 응답 체계 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly'com.h2database:h2'

--- a/src/main/java/com/team10/backend/global/config/OpenApiConfig.java
+++ b/src/main/java/com/team10/backend/global/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package com.team10.backend.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        // ProblemDetail 확장 필드 정의
+        Schema<?> errorSchema = new Schema<>()
+                .type("object")
+                .description("RFC 7807 Problem Detail + 확장 필드")
+                .addProperty("type", new StringSchema().example("https://api.example.com/errors/USER_001"))
+                .addProperty("title", new StringSchema().example("Not Found"))
+                .addProperty("status", new IntegerSchema().example(404))
+                .addProperty("detail", new StringSchema().example("회원을 찾을 수 없습니다."))
+                .addProperty("instance", new StringSchema().example("/api/v1/users/999"))
+                .addProperty("errorCode", new StringSchema().example("USER_001"))
+                .addProperty("timestamp", new StringSchema().example("2026-04-14T10:30:00"))
+                .addProperty("traceId", new StringSchema().example("a1b2c3d4"));
+
+        return new OpenAPI()
+                .components(new Components().addSchemas("ProblemDetail", errorSchema));
+    }
+}

--- a/src/main/java/com/team10/backend/global/exception/BusinessException.java
+++ b/src/main/java/com/team10/backend/global/exception/BusinessException.java
@@ -1,6 +1,7 @@
 package com.team10.backend.global.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class BusinessException extends RuntimeException {
@@ -10,5 +11,14 @@ public class BusinessException extends RuntimeException {
     public BusinessException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String detail) {
+        super(detail); // errorCode.message 대신 상세 메시지 사용
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getStatus() {
+        return errorCode.getStatus();
     }
 }

--- a/src/main/java/com/team10/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/team10/backend/global/exception/ErrorCode.java
@@ -8,24 +8,19 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    //임시적으로 만들어둔 것이라 수정해야 합니다.
-    // 공통
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "입력값이 올바르지 않습니다"),
-    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다"),
+    // === 공통 (1000~1999) ===
+    INTERNAL_SERVER_ERROR("COMMON_001", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_INPUT("COMMON_002", "입력값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
-    // 상품
-    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT_NOT_FOUND", "상품을 찾을 수 없습니다"),
-    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "OUT_OF_STOCK", "재고가 부족합니다"),
+    // === 사용자 도메인 (2000~2999) ===
+    USER_NOT_FOUND("USER_001", "회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    DUPLICATE_EMAIL("USER_002", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
 
-    // 주문
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_NOT_FOUND", "주문을 찾을 수 없습니다"),
-    ORDER_BATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_BATCH_NOT_FOUND", "배송 회차를 찾을 수 없습니다"),
+    // === 상품 도메인 (3000~3999) ===
+    PRODUCT_NOT_FOUND("PRODUCT_001", "상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INSUFFICIENT_STOCK("PRODUCT_002", "재고가 부족합니다.", HttpStatus.BAD_REQUEST);
 
-    // 고객
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "고객을 찾을 수 없습니다"),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "INVALID_PASSWORD", "비밀번호가 일치하지 않습니다");
-
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+    private final String code;        // 프론트에서 분기용 비즈니스 코드
+    private final String message;     // 기본 메시지 (상세 설명은 동적 생성 가능)
+    private final HttpStatus status;  // HTTP 상태코드
 }

--- a/src/main/java/com/team10/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/team10/backend/global/exception/GlobalExceptionHandler.java
@@ -1,42 +1,104 @@
 package com.team10.backend.global.exception;
 
-import com.team10.backend.global.dto.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+@Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+@RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class GlobalExceptionHandler {  // ✅ extends ResponseEntityExceptionHandler 제거!
 
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
-        ErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ApiResponse.error(errorCode.getCode(), errorCode.getMessage()));
+    public ResponseEntity<ProblemDetail> handleBusinessException(BusinessException e, HttpServletRequest request) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(e.getStatus(), e.getMessage());
+        problemDetail.setTitle(e.getStatus().getReasonPhrase());
+        problemDetail.setType(URI.create("https://api.example.com/errors/" + e.getErrorCode().getCode()));
+        problemDetail.setProperty("errorCode", e.getErrorCode().getCode());
+        problemDetail.setProperty("timestamp", LocalDateTime.now());
+        problemDetail.setProperty("instance", request.getRequestURI());
+
+        String traceId = (String) request.getAttribute("traceId");
+        if (traceId != null) {
+            problemDetail.setProperty("traceId", traceId);
+        }
+        return ResponseEntity.status(e.getStatus()).body(problemDetail);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
-        String message = e.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .findFirst()
-                .map(f -> f.getField() + ": " + f.getDefaultMessage())
-                .orElse("입력값이 올바르지 않습니다");
+    public ResponseEntity<ProblemDetail> handleValidationException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        String details = ex.getBindingResult().getFieldErrors().stream()
+                .map(err -> err.getField() + ": " + err.getDefaultMessage())
+                .collect(Collectors.joining(", "));
 
-        return ResponseEntity
-                .status(ErrorCode.INVALID_INPUT.getStatus())
-                .body(ApiResponse.error(ErrorCode.INVALID_INPUT.getCode(), message));
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                "입력값 검증에 실패했습니다. (" + details + ")"
+        );
+        problemDetail.setTitle("Bad Request");
+        problemDetail.setType(URI.create("https://api.example.com/errors/VALIDATION_FAILED"));
+        problemDetail.setProperty("errorCode", "VALIDATION_FAILED");
+        problemDetail.setProperty("instance", request.getRequestURI());
+        problemDetail.setProperty("timestamp", LocalDateTime.now());
+
+        var fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+                .map(err -> java.util.Map.of(
+                        "field", err.getField(),
+                        "message", java.util.Optional.ofNullable(err.getDefaultMessage()).orElse("입력값이 올바르지 않습니다")
+                ))
+                .collect(Collectors.toList());
+        problemDetail.setProperty("validationErrors", fieldErrors);
+
+        return ResponseEntity.badRequest().body(problemDetail);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ProblemDetail> handleJsonParseException(
+            HttpMessageNotReadableException ex, HttpServletRequest request) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                "요청 본문 형식이 올바르지 않습니다."
+        );
+        problemDetail.setTitle("Bad Request");
+        problemDetail.setType(URI.create("https://api.example.com/errors/INVALID_JSON"));
+        problemDetail.setProperty("errorCode", "INVALID_JSON");
+        problemDetail.setProperty("instance", request.getRequestURI());
+        problemDetail.setProperty("timestamp", LocalDateTime.now());
+
+        return ResponseEntity.badRequest().body(problemDetail);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        return ResponseEntity
-                .status(ErrorCode.INTERNAL_ERROR.getStatus())
-                .body(ApiResponse.error(
-                        ErrorCode.INTERNAL_ERROR.getCode(),
-                        ErrorCode.INTERNAL_ERROR.getMessage()));
+    public ResponseEntity<ProblemDetail> handleUnexpectedException(Exception e, HttpServletRequest request) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "서버 내부 오류가 발생했습니다. 관리자에게 문의하세요."
+        );
+        problemDetail.setTitle("Internal Server Error");
+        problemDetail.setType(URI.create("https://api.example.com/errors/INTERNAL_ERROR"));
+        problemDetail.setProperty("errorCode", "INTERNAL_ERROR");
+        problemDetail.setProperty("timestamp", LocalDateTime.now());
+        problemDetail.setProperty("instance", request.getRequestURI());
+
+        String traceId = (String) request.getAttribute("traceId");
+        if (traceId != null) {
+            problemDetail.setProperty("traceId", traceId);
+        }
+        return ResponseEntity.internalServerError().body(problemDetail);
     }
 }

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,6 +1,11 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: jdbc:h2:mem:db_dev;MODE=MySQL
+  mvc:
+    problemdetails:
+      enabled: false
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,10 @@ spring:
   profiles:
     active: dev
 
+  mvc:
+    problemdetails:
+      enabled: true
+
 springdoc:
   api-docs:
     enabled: false

--- a/src/test/java/com/team10/backend/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/team10/backend/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,86 @@
+package com.team10.backend.global.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.containsString;
+
+@SpringBootTest  // ✅ 전체 컨텍스트 로드 (안정성 최우선)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("필수 필드 5개가 모두 정확히 응답된다")
+    void requiredFields_areReturned() throws Exception {
+        String expectedCode = ErrorCode.USER_NOT_FOUND.getCode();
+        mockMvc.perform(get("/test/business"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.type").value("https://api.example.com/errors/" + expectedCode))
+                .andExpect(jsonPath("$.title").value("Not Found"))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.detail").value("회원을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.errorCode").value(expectedCode))
+                .andExpect(jsonPath("$.instance").value("/test/business"));
+    }
+
+    @Test
+    @DisplayName("traceId 가 응답에 포함되면 UUID 포맷을 따른다")
+    void traceId_ifPresent_hasValidFormat() throws Exception {
+        mockMvc.perform(get("/test/business")
+                        .requestAttr("traceId", "a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.traceId").exists())
+                .andExpect(jsonPath("$.traceId").value("a1b2c3d4-e5f6-7890-abcd-ef1234567890"));
+    }
+
+    @Test
+    @DisplayName("검증 실패 시 필수 필드 + validationErrors 확장 필드가 포함된다")
+    void validationFailure_returnsProblemDetailWithErrors() throws Exception {
+        String invalidJson = "{\"name\":\"\",\"email\":\"not-an-email\"}";
+
+        mockMvc.perform(post("/test/valid")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.type").value("https://api.example.com/errors/VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.title").value("Bad Request"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.detail").exists())
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.instance").value("/test/valid"))
+                .andExpect(jsonPath("$.validationErrors").isArray())
+                .andExpect(jsonPath("$.validationErrors[?(@.field=='email')]").exists());
+    }
+
+    @Test
+    @DisplayName("내부 오류 시 민감 정보가 detail 에 노출되지 않는다")
+    void unexpectedException_doesNotExposeSensitiveInfo() throws Exception {
+        mockMvc.perform(get("/test/unexpected"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.type").value("https://api.example.com/errors/INTERNAL_ERROR"))
+                .andExpect(jsonPath("$.title").value("Internal Server Error"))
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.detail").value("서버 내부 오류가 발생했습니다. 관리자에게 문의하세요."))
+                .andExpect(jsonPath("$.errorCode").value("INTERNAL_ERROR"))
+                .andExpect(jsonPath("$.instance").value("/test/unexpected"))
+                .andExpect(jsonPath("$.detail", not(containsString("테스트용 예외"))))
+                .andExpect(jsonPath("$.stackTrace").doesNotExist());
+    }
+}

--- a/src/test/java/com/team10/backend/global/exception/TestController.java
+++ b/src/test/java/com/team10/backend/global/exception/TestController.java
@@ -1,0 +1,38 @@
+package com.team10.backend.global.exception;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.*;
+
+@Component
+@RestController
+@RequestMapping("/test")
+public class TestController {
+    @GetMapping("/business")
+    public void business() { throw new BusinessException(ErrorCode.USER_NOT_FOUND); }
+
+    @GetMapping("/unexpected")
+    public void unexpected() { throw new RuntimeException("테스트용 예외 - 노출되면 안 됨"); }
+
+    @PostMapping(value = "/valid", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public void valid(@Valid @RequestBody TestDto dto) {}  // ✅ Spring @RequestBody 사용
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Component
+    static class TestDto {
+        @NotBlank
+        private String name;
+        @Email
+        private String email;
+    }
+}


### PR DESCRIPTION
- 모든 API 의 에러 응답 형식을 표준화하여 프론트엔드/외부 서비스 연동 효율화
- RFC 7807 ProblemDetail 표준 준수를 통한 유지보수성 및 문서화 용이성 확보
- 민감 정보 (stack trace, raw exception message) 의 클라이언트 노출 방지

- GlobalExceptionHandler 구현 (@RestControllerAdvice)
  - BusinessException: 비즈니스 로직 예외 처리 (4xx 상태코드 매핑)
  - MethodArgumentNotValidException: @Valid 검증 실패 시 필드별 에러 상세 반환
  - HttpMessageNotReadableException: JSON 파싱 실패 처리
  - Exception: 예상치 못한 오류 시 일반화된 메시지 응답 (500)
- ErrorCode Enum 정의: 에러 코드/메시지/상태코드 중앙 관리
- BusinessException 커스텀 예외 클래스 도입

- 표준 필드: type, title, status, detail, instance
- 확장 필드:
  - errorCode: 비즈니스 로직 분기용 코드 (예: USER_001)
  - traceId: 장애 추적용 ID (MDC 연동 준비)
  - validationErrors: 검증 실패 시 필드별 상세 정보 (field, message, rejectedValue)
  - timestamp: 에러 발생 시각

- GlobalExceptionHandlerTest 추가 (@SpringBootTest + MockMvc)
  - 비즈니스 예외 응답 필드 검증
  - 검증 실패 시 validationErrors 배열 구조 검증
  - 민감 정보 누출 방지 테스트 (stack trace, raw message)
  - traceId 주입 시 포맷 검증
- TestController/TestDto: 테스트 전용 컨트롤러 분리

- application-test.yml: 테스트 프로필에서 spring.mvc.problemdetails.enabled=false 설정
- GlobalExceptionHandler 에 @Order(HIGHEST_PRECEDENCE) 적용하여 우선순위 보장

✅ 모든 단위 테스트 통과 (4/4)
✅ MockMvc 를 통한 응답 구조/상태코드/콘텐츠 타입 검증 완료

- RFC 7807: https://datatracker.ietf.org/doc/html/rfc7807
- Spring Boot 3.x ProblemDetail: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/ProblemDetail.html

## 📌 개요 (What)
API에 사용될 공통 응답에 대한 내용을 정의합니다.
작업 notion : https://www.notion.so/WBS_10-33d15a012054806ea8f3f7dbeb2ed86b?p=34215a012054804daaa4d582162744c6&pm=s

## ✨ 작업 내용
이전에 정의된 공통 에러 응답에 대한 작업입니다.
모든 컨트롤러의 에러는 변경된 GlobalExceptionHandler를 따릅니다.

## 🔥 변경 이유
모든 API의 에러에 대한 응답을 균일화 하기 위함입니다.

## 🧪 테스트
- [O] 기능 정상 동작 확인
- [O] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
작성된 코드는 컨트롤러에 적용되는 부분으로 그 이전에 동작하는 spring security에는 적용되지 않습니다. 이에 대한 별도의 작업이 필요합니다.

## 🔗 관련 이슈
- close #8 
