### PR TITLE
feat: 상품 전체 조회

### DIFF
--- a/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
@@ -10,6 +10,7 @@ import com.team10.backend.global.exception.BusinessException;
 import com.team10.backend.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,8 +22,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/stores/me/products")
-@Tag(name = "상품", description = "상품 관련 API")
-public class ProductController {
+@Tag(name = "상품 관리", description = "상품 등록/수정/삭제 API")
+public class ProductCommandController {
 
     private final UserRepository userRepository;
     private final ProductService productService;
@@ -30,11 +31,13 @@ public class ProductController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "상품 등록", description = "판매자가 신규 상품을 등록합니다.")
-    public ApiResponse<ProductResponse> create(@RequestBody ProductCreateRequest request) {
+    public ApiResponse<ProductResponse> create(@RequestBody @Valid ProductCreateRequest request) {
         User user = userRepository.findById(1L)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         ProductResponse response = productService.create(user, request);
         return ApiResponse.ok(response);
     }
+
+
 }

--- a/src/main/java/com/team10/backend/domain/product/controller/ProductController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductController.java
@@ -12,7 +12,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/team10/backend/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductQueryController.java
@@ -1,0 +1,36 @@
+package com.team10.backend.domain.product.controller;
+
+import com.team10.backend.domain.product.dto.ProductPageResponse;
+import com.team10.backend.domain.product.enums.ProductStatus;
+import com.team10.backend.domain.product.enums.ProductType;
+import com.team10.backend.domain.product.service.ProductService;
+import com.team10.backend.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products")
+@Tag(name = "상품 조회", description = "상품 조회 API")
+public class ProductQueryController {
+
+    private final ProductService productService;
+
+    @GetMapping
+    @Operation(summary = "상품 전체 조회",
+            description = "등록된 상품 목록을 최신순으로 조회하며, 페이지 및 필터 조건을 지원합니다.")
+    public ApiResponse<ProductPageResponse> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) ProductType type,
+            @RequestParam(required = false) ProductStatus status
+    ) {
+        ProductPageResponse response = productService.list(page, size, type, status);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductCreateRequest.java
@@ -1,13 +1,28 @@
 package com.team10.backend.domain.product.dto;
 
 import com.team10.backend.domain.product.enums.ProductType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record ProductCreateRequest(
+
+        @NotBlank(message = "상품명은 필수입니다.")
+        @Size(max = 30, message = "상품명은 30자 이하여야 합니다.")
         String productName,
+
         String description,
+
+        @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
         int price,
+
+        @Min(value = 0, message = "재고는 0 이상이어야 합니다.")
         int stock,
+
         String imageUrl,
+
+        @NotNull(message = "상품 종류를 선택해 주세요.")
         ProductType type
 ) {
 }

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductCreateRequest.java
@@ -4,8 +4,10 @@ import com.team10.backend.domain.product.enums.ProductType;
 
 public record ProductCreateRequest(
         String productName,
+        String description,
         int price,
         int stock,
+        String imageUrl,
         ProductType type
 ) {
 }

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductPageResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductPageResponse.java
@@ -1,0 +1,12 @@
+package com.team10.backend.domain.product.dto;
+
+import java.util.List;
+
+public record ProductPageResponse(
+        List<ProductResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductResponse.java
@@ -7,8 +7,10 @@ import com.team10.backend.domain.product.enums.ProductType;
 public record ProductResponse(
         Long productId,
         String productName,
+        String description,
         int price,
         int stock,
+        String imageUrl,
         ProductType type,
         ProductStatus status
 ) {
@@ -16,8 +18,10 @@ public record ProductResponse(
         return new ProductResponse(
                 product.getId(),
                 product.getProductName(),
+                product.getDescription(),
                 product.getPrice(),
                 product.getStock(),
+                product.getImageUrl(),
                 product.getType(),
                 product.getStatus()
         );

--- a/src/main/java/com/team10/backend/domain/product/entity/Product.java
+++ b/src/main/java/com/team10/backend/domain/product/entity/Product.java
@@ -33,22 +33,32 @@ public class Product extends BaseEntity {
     @Column(name = "product_name", nullable = false)
     private String productName;
 
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
     @Column(nullable = false)
     private int price;
 
     @Column(nullable = false)
     private int stock;
 
+    @Column(name = "image_url")
+    private String imageUrl;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ProductStatus status;
 
-    public Product(User user, ProductType type, String productName, int price, int stock) {
+
+
+    public Product(User user, ProductType type, String productName, String description, int price, int stock, String imageUrl) {
         this.user = user;
         this.type = type;
         this.productName = productName;
+        this.description = description;
         this.price = price;
         this.stock = stock;
+        this.imageUrl = imageUrl;
         this.status = ProductStatus.SELLING;
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/entity/Product.java
+++ b/src/main/java/com/team10/backend/domain/product/entity/Product.java
@@ -50,7 +50,6 @@ public class Product extends BaseEntity {
     private ProductStatus status;
 
 
-
     public Product(User user, ProductType type, String productName, String description, int price, int stock, String imageUrl) {
         this.user = user;
         this.type = type;
@@ -60,5 +59,9 @@ public class Product extends BaseEntity {
         this.stock = stock;
         this.imageUrl = imageUrl;
         this.status = ProductStatus.SELLING;
+    }
+
+    public void updateStatus(ProductStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/team10/backend/domain/product/repository/ProductRepository.java
@@ -1,7 +1,17 @@
 package com.team10.backend.domain.product.repository;
 
 import com.team10.backend.domain.product.entity.Product;
+import com.team10.backend.domain.product.enums.ProductStatus;
+import com.team10.backend.domain.product.enums.ProductType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    Page<Product> findByType(ProductType type, Pageable pageable);
+
+    Page<Product> findByStatus(ProductStatus status, Pageable pageable);
+
+    Page<Product> findByTypeAndStatus(ProductType type, ProductStatus status, Pageable pageable);
 }

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -21,8 +21,10 @@ public class ProductService {
                 user,
                 request.type(),
                 request.productName(),
+                request.description(),
                 request.price(),
-                request.stock()
+                request.stock(),
+                request.imageUrl()
         );
 
         Product savedProduct = productRepository.save(product);

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -45,7 +45,7 @@ public class ProductService {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        Page<Product> productPage = productRepository.findAll(pageable);
+        Page<Product> productPage;
 
         if (type != null && status != null) productPage = productRepository.findByTypeAndStatus(type, status, pageable);
         else if (type != null) productPage = productRepository.findByType(type, pageable);

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -1,13 +1,22 @@
 package com.team10.backend.domain.product.service;
 
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
+import com.team10.backend.domain.product.dto.ProductPageResponse;
 import com.team10.backend.domain.product.dto.ProductResponse;
 import com.team10.backend.domain.product.entity.Product;
+import com.team10.backend.domain.product.enums.ProductStatus;
+import com.team10.backend.domain.product.enums.ProductType;
 import com.team10.backend.domain.product.repository.ProductRepository;
 import com.team10.backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -29,5 +38,32 @@ public class ProductService {
 
         Product savedProduct = productRepository.save(product);
         return ProductResponse.from(savedProduct);
+    }
+
+    @Transactional(readOnly = true)
+    public ProductPageResponse list(int page, int size, ProductType type, ProductStatus status) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        Page<Product> productPage = productRepository.findAll(pageable);
+
+        if (type != null && status != null) productPage = productRepository.findByTypeAndStatus(type, status, pageable);
+        else if (type != null) productPage = productRepository.findByType(type, pageable);
+        else if (status != null) productPage = productRepository.findByStatus(status, pageable);
+        else productPage = productRepository.findAll(pageable);
+
+
+        List<ProductResponse> content = productPage.getContent()
+                .stream()
+                .map(ProductResponse::from)
+                .toList();
+
+        return new ProductPageResponse(
+                content,
+                productPage.getNumber(),
+                productPage.getSize(),
+                productPage.getTotalElements(),
+                productPage.getTotalPages()
+        );
     }
 }

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class ProductControllerTest {
+class ProductCommandControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductQueryControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductQueryControllerTest.java
@@ -1,0 +1,72 @@
+package com.team10.backend.domain.product.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class ProductQueryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("상품 전체 조회 성공")
+    void listProducts_success() throws Exception {
+        mockMvc.perform(get("/api/v1/products")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.size").value(10));
+    }
+
+    @Test
+    @DisplayName("상품 전체 조회 시, type 필터 적용 성공")
+    void listProducts_withTypeFilter_success() throws Exception {
+        mockMvc.perform(get("/api/v1/products")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("type", "BOOK"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content").isArray());
+    }
+
+    @Test
+    @DisplayName("상품 전체 조회 시, status 필터 적용 성공")
+    void listProducts_withStatusFilter_success() throws Exception {
+        mockMvc.perform(get("/api/v1/products")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("status", "SELLING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content").isArray());
+    }
+
+    @Test
+    @DisplayName("상품 전체 조회 시 type, status 필터 적용 성공")
+    void listProducts_withTypeAndStatusFilter_success() throws Exception {
+        mockMvc.perform(get("/api/v1/products")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("type", "BOOK")
+                        .param("status", "SELLING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content").isArray());
+    }
+}

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -61,14 +61,16 @@ class ProductServiceTest {
     void createProduct_defaultStatusSelling() {
         User user = userRepository.findById(1L).orElseThrow();
 
-        ProductCreateRequest request = new ProductCreateRequest("ABC", 10000, 100, ProductType.BOOK);
+        ProductCreateRequest request = new ProductCreateRequest("ABC", "책 설명입니다.", 10000, 100, null, ProductType.BOOK);
         ProductResponse response = productService.create(user, request);
 
         assertThat(response.productId()).isNotNull();
         assertThat(response.productName()).isEqualTo("ABC");
+        assertThat(response.description()).isEqualTo("책 설명입니다.");
         assertThat(response.price()).isEqualTo(10000);
         assertThat(response.stock()).isEqualTo(100);
         assertThat(response.type()).isEqualTo(ProductType.BOOK);
+        assertThat(response.imageUrl()).isNull();
         assertThat(response.status()).isEqualTo(ProductStatus.SELLING);
         assertThat(productRepository.count()).isEqualTo(1);
     }

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -1,7 +1,9 @@
 package com.team10.backend.domain.product.service;
 
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
+import com.team10.backend.domain.product.dto.ProductPageResponse;
 import com.team10.backend.domain.product.dto.ProductResponse;
+import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
 import com.team10.backend.domain.product.repository.ProductRepository;
@@ -73,5 +75,76 @@ class ProductServiceTest {
         assertThat(response.imageUrl()).isNull();
         assertThat(response.status()).isEqualTo(ProductStatus.SELLING);
         assertThat(productRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("상품 전체 조회 시, 상품 목록과 페이지 정보 반환")
+    void listProducts_withPaging() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        productRepository.save(new Product(user, ProductType.BOOK, "책1", "설명1", 10000, 10, null));
+        productRepository.save(new Product(user, ProductType.BOOK, "책2", "설명2", 20000, 20, null));
+
+        ProductPageResponse response = productService.list(0, 10, null, null);
+
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.page()).isEqualTo(0);
+        assertThat(response.size()).isEqualTo(10);
+        assertThat(response.totalElements()).isEqualTo(2);
+        assertThat(response.totalPages()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("상품 전체 조회 시, type 필터로 상품 조회")
+    void listProducts_withTypeFilter() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        productRepository.save(new Product(user, ProductType.BOOK, "책1", "설명1", 10000, 10, null));
+        productRepository.save(new Product(user, ProductType.EBOOK, "굿즈1", "설명2", 20000, 20, null));
+
+        ProductPageResponse response = productService.list(0, 10, ProductType.BOOK, null);
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).productName()).isEqualTo("책1");
+        assertThat(response.content().get(0).type()).isEqualTo(ProductType.BOOK);
+    }
+
+    @Test
+    @DisplayName("상품 전체 조회 시, status 필터로 상품 조회")
+    void listProducts_withStatusFilter() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        productRepository.save(new Product(user, ProductType.BOOK, "책1", "설명1", 10000, 10, null));
+
+        Product inactiveProduct = new Product(user, ProductType.EBOOK, "전자책1", "설명2", 20000, 20, null);
+        inactiveProduct.updateStatus(ProductStatus.INACTIVE);
+        productRepository.save(inactiveProduct);
+
+        ProductPageResponse response = productService.list(0, 10, null, ProductStatus.SELLING);
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).productName()).isEqualTo("책1");
+        assertThat(response.content().get(0).status()).isEqualTo(ProductStatus.SELLING);
+    }
+
+    @Test
+    @DisplayName("상품 전체 조회 시, type과 status 필터로 상품 조회")
+    void listProducts_withTypeAndStatusFilter() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        productRepository.save(new Product(user, ProductType.BOOK, "책1", "설명1", 10000, 10, null));
+
+        Product inactiveBook = new Product(user, ProductType.BOOK, "책2", "설명2", 15000, 5, null);
+        inactiveBook.updateStatus(ProductStatus.INACTIVE);
+        productRepository.save(inactiveBook);
+
+        productRepository.save(new Product(user, ProductType.EBOOK, "전자책1", "설명3", 20000, 20, null));
+
+        ProductPageResponse response = productService.list(0, 10, ProductType.BOOK, ProductStatus.SELLING);
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).productName()).isEqualTo("책1");
+        assertThat(response.content().get(0).type()).isEqualTo(ProductType.BOOK);
+        assertThat(response.content().get(0).status()).isEqualTo(ProductStatus.SELLING);
     }
 }


### PR DESCRIPTION
## 📌 개요 (What)
상품 전체 조회 기능 구현했습니다.

## ✨ 작업 내용
- 상품 전체 조회 API 구현
- 페이지네이션(page, size) 적용
- type, status 필터 기능 추가
- ProductCommandController / ProductQueryController 분리
- 상품 목록 페이지 응답 DTO(ProductPageResponse) 추가
- 상품 설명(description), 이미지 URL(imageUrl) 필드 반영
- 서비스, 컨트롤러 테스트 코드 작성

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
- 조회 시 최근에 상품을 등록한 순서로 나옵니다.
- Page는 0부터 시작하고, type과 status로 필터합니다.

## 🔗 관련 이슈
- close #17 