### PR TITLE
Feat/order create

### DIFF
--- a/src/main/java/com/team10/backend/domain/order/controller/OrderController.java
+++ b/src/main/java/com/team10/backend/domain/order/controller/OrderController.java
@@ -4,6 +4,8 @@ import com.team10.backend.domain.order.dto.OrderCreateRequest;
 import com.team10.backend.domain.order.dto.OrderResponse;
 import com.team10.backend.domain.order.service.OrderService;
 import com.team10.backend.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,11 +16,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/orders")
 @RequiredArgsConstructor
+@Tag(name = "주문", description = "주문 관련 API")
 public class OrderController {
 
     private final OrderService orderService;
 
     @PostMapping
+    @Operation(summary = "주문 등록", description = "구매자가 상품을 구매할때 주문을 생성합니다.")
     public ApiResponse<OrderResponse> createOrder(@RequestBody @Valid OrderCreateRequest req) {
         OrderResponse response = orderService.createOrder(req);
         return ApiResponse.ok(response);

--- a/src/main/java/com/team10/backend/domain/order/controller/OrderController.java
+++ b/src/main/java/com/team10/backend/domain/order/controller/OrderController.java
@@ -1,0 +1,27 @@
+package com.team10.backend.domain.order.controller;
+
+import com.team10.backend.domain.order.dto.OrderCreateRequest;
+import com.team10.backend.domain.order.dto.OrderResponse;
+import com.team10.backend.domain.order.service.OrderService;
+import com.team10.backend.global.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ApiResponse<OrderResponse> createOrder(@RequestBody @Valid OrderCreateRequest req) {
+        OrderResponse response = orderService.createOrder(req);
+        return ApiResponse.ok(response);
+    }
+
+}

--- a/src/main/java/com/team10/backend/domain/order/dto/OrderCreateRequest.java
+++ b/src/main/java/com/team10/backend/domain/order/dto/OrderCreateRequest.java
@@ -1,0 +1,34 @@
+package com.team10.backend.domain.order.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/*
+* {
+  "userId": 1,
+  "deliveryAddress": "서울특별시 .....",
+  "items": [
+    { "productId": 101, "quantity": 2 },
+    { "productId": 105, "quantity": 1 }
+  ]
+}*/
+public record OrderCreateRequest(
+
+        Long userId,
+
+        @NotBlank(message = "배송 주소는 필수입니다")
+        String deliveryAddress,
+
+        @NotEmpty(message = "상품을 최소 1개 이상 선택해야 합니다")
+        List<OrderProductReq> orderProducts
+) {
+    public record OrderProductReq(
+            Long productId,
+            @Min(1)
+            int quantity
+    ) {}
+}

--- a/src/main/java/com/team10/backend/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/team10/backend/domain/order/dto/OrderResponse.java
@@ -1,0 +1,17 @@
+package com.team10.backend.domain.order.dto;
+
+import com.team10.backend.domain.order.entity.Order;
+
+public record OrderResponse(
+        String orderNumber,     // 토스 전송용 orderNumber
+        int totalAmount,        // 최종 결제 금액
+        Long userId // 구매자 이름
+){
+    public static OrderResponse from(Order order) {
+        return new OrderResponse(
+                order.getOrderNumber(),
+                order.getTotalAmount(), // Order 엔티티에 해당 필드가 있다고 가정
+                order.getUser().getId() // User 객체에서 ID를 추출
+        );
+    }
+}

--- a/src/main/java/com/team10/backend/domain/order/entity/Order.java
+++ b/src/main/java/com/team10/backend/domain/order/entity/Order.java
@@ -1,30 +1,96 @@
 package com.team10.backend.domain.order.entity;
 
+import com.team10.backend.domain.order.enums.PaymentStatus;
 import com.team10.backend.domain.user.entity.User;
 import com.team10.backend.global.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "orders")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "order_number")
+    // 외부(토스 등)에 노출할 고유 주문 번호
+    @Column(name = "order_number", nullable = false, unique = true)//유니크로 설정
     private String orderNumber;
 
     @Column(name="total_amount")
     private int totalAmount;
 
-    @Column(name="delivery_address")
-    private String deliveryAddress;
+    @Builder
+    private Order(User user, String orderNumber, int totalAmount) {
+        this.user = user;
+        this.orderNumber = orderNumber;
+        this.totalAmount = totalAmount;
+    }
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderProducts> orderProducts = new ArrayList<>();
+
+    @OneToOne(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private OrderDelivery delivery;
+
+    // 추가: 결제 이력을 관리하기 위한 리스트 (1:N)
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Payment> payments = new ArrayList<>();
+
+    // == 생성 메서드 ==
+    public static Order createOrder(User user, String orderNumber, OrderDelivery delivery, List<OrderProducts> items) {
+        //총 합을 구한다.
+        int calculatedTotalAmount = items.stream()
+                .mapToInt(item -> item.getOrderPrice() * item.getQuantity())
+                .sum();
+
+        //오더 생성
+        Order order = Order.builder()
+                .user(user)
+                .orderNumber(orderNumber)
+                .totalAmount(calculatedTotalAmount)
+                .build();
+
+        // 양방향 관계 설정
+        order.setDelivery(delivery);
+        items.forEach(order::addOrderProduct);
+
+        // 추가: 주문 생성 시점에 초기 결제(Payment) 객체도 함께 생성하여 포함시킴
+        Payment initialPayment = Payment.builder()
+                .order(order)
+                .orderNumber(orderNumber)
+                .totalAmount(calculatedTotalAmount) // Payment 설계에 맞게 Long 형변환
+                .status(PaymentStatus.READY)
+                .build();
+        order.addPayment(initialPayment);
+
+        return order;
+    }
+
+    // == 연관관계 편의 메서드 ==
+    private void setDelivery(OrderDelivery delivery) {
+        this.delivery = delivery;
+        delivery.setOrder(this);
+    }
+
+    private void addOrderProduct(OrderProducts orderProduct) {
+        this.orderProducts.add(orderProduct);
+        orderProduct.setOrder(this);
+    }
+
+    public void addPayment(Payment payment) {
+        this.payments.add(payment);
+        // Payment 엔티티에 setOrder 메서드가 필요합니다 (OrderDelivery처럼)
+        payment.setOrder(this);
+    }
 
 }

--- a/src/main/java/com/team10/backend/domain/order/entity/OrderDelivery.java
+++ b/src/main/java/com/team10/backend/domain/order/entity/OrderDelivery.java
@@ -1,0 +1,36 @@
+package com.team10.backend.domain.order.entity;
+
+import com.team10.backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "order_delivery")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderDelivery extends BaseEntity {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Column(name="delivery_address")
+    private String delivery_address;
+
+    @Column(name = "tracking_number")
+    private String tracking_number;
+
+    @Builder
+    private OrderDelivery(String delivery_address,String tracking_number) {
+        this.delivery_address = delivery_address;
+        this.tracking_number = tracking_number;
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+
+}

--- a/src/main/java/com/team10/backend/domain/order/entity/OrderProducts.java
+++ b/src/main/java/com/team10/backend/domain/order/entity/OrderProducts.java
@@ -1,0 +1,39 @@
+package com.team10.backend.domain.order.entity;
+
+import com.team10.backend.domain.product.entity.Product;
+import com.team10.backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "order_products")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderProducts extends BaseEntity {
+
+    // Order와의 연관관계를 맺어주는 핵심 메서드
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    private int orderPrice; // 주문 당시의 가격
+
+    @Builder
+    private OrderProducts(Product product, int quantity, int orderPrice) {
+        this.product = product;
+        this.quantity = quantity;
+        this.orderPrice = orderPrice;
+    }
+
+    // Order와의 연관관계를 맺어주는 핵심 메서드
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/src/main/java/com/team10/backend/domain/order/entity/Payment.java
+++ b/src/main/java/com/team10/backend/domain/order/entity/Payment.java
@@ -1,0 +1,57 @@
+package com.team10.backend.domain.order.entity;
+
+import com.team10.backend.domain.order.enums.PaymentStatus;
+import com.team10.backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@Table(name = "payments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseEntity {
+
+    @Column(name = "order_number", nullable = false, unique = true)
+    private String orderNumber; // 토스 전송용 고유 번호 (ORD-2026...)
+
+    @Column(name = "total_amount", nullable = false)
+    private int totalAmount; // 결제 예정 금액
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PaymentStatus status; // READY, PAID, FAILED
+
+    @Column(name = "payment_key")
+    private String paymentKey; // 결제 승인 후 토스에서 받는 키 (초기엔 null)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Builder
+    private Payment(Order order, String orderNumber, int totalAmount, PaymentStatus status) {
+        this.order = order;
+        this.orderNumber = orderNumber;
+        this.totalAmount = totalAmount;
+        this.status = status != null ? status : PaymentStatus.READY;
+    }
+
+    // 결제 승인 완료 시 호출할 비즈니스 메서드
+    public void completePayment(String paymentKey) {
+        this.paymentKey = paymentKey;
+        this.status = PaymentStatus.PAID;
+    }
+
+    // 결제 실패 시 호출
+    public void failPayment() {
+        this.status = PaymentStatus.FAILED;
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/src/main/java/com/team10/backend/domain/order/enums/PaymentStatus.java
+++ b/src/main/java/com/team10/backend/domain/order/enums/PaymentStatus.java
@@ -1,0 +1,7 @@
+package com.team10.backend.domain.order.enums;
+
+public enum PaymentStatus {
+    READY,      // 결제 대기 (가주문 상태)
+    PAID,       // 결제 완료
+    FAILED;   // 결제 실패
+}

--- a/src/main/java/com/team10/backend/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/team10/backend/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.team10.backend.domain.order.repository;
+
+import com.team10.backend.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order,Long> {
+}

--- a/src/main/java/com/team10/backend/domain/order/service/OrderService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/OrderService.java
@@ -7,7 +7,9 @@ import com.team10.backend.domain.order.entity.OrderDelivery;
 import com.team10.backend.domain.order.entity.OrderProducts;
 import com.team10.backend.domain.order.repository.OrderRepository;
 import com.team10.backend.domain.product.entity.Product;
+import com.team10.backend.domain.product.repository.ProductRepository;
 import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.user.repository.UserRepository;
 import com.team10.backend.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -60,14 +62,14 @@ public class OrderService {
 
     //유저 찾기
     public User findUser(OrderCreateRequest request) {
-        return userRepository.findById(request.user_id())
+        return userRepository.findById(request.userId())
                 .orElseThrow(() ->new BusinessException(USER_NOT_FOUND,"해당 유저 정보를 찾을 수 없습니다."));
     }
 
     //order-delivery 테이블에 배송지, 운송장 번호 생성
     public OrderDelivery deliveryInfo(OrderCreateRequest request) {
         return  OrderDelivery.builder()
-                .delivery_address(request.delivery_address())
+                .delivery_address(request.deliveryAddress())
                 .tracking_number(null) // 송장 번호를 여기서 만들어야 하나?
                 .build();
     }

--- a/src/main/java/com/team10/backend/domain/order/service/OrderService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/OrderService.java
@@ -1,0 +1,93 @@
+package com.team10.backend.domain.order.service;
+
+import com.team10.backend.domain.order.dto.OrderCreateRequest;
+import com.team10.backend.domain.order.dto.OrderResponse;
+import com.team10.backend.domain.order.entity.Order;
+import com.team10.backend.domain.order.entity.OrderDelivery;
+import com.team10.backend.domain.order.entity.OrderProducts;
+import com.team10.backend.domain.order.repository.OrderRepository;
+import com.team10.backend.domain.product.entity.Product;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static com.team10.backend.global.exception.ErrorCode.PRODUCT_NOT_FOUND;
+import static com.team10.backend.global.exception.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public OrderResponse createOrder(OrderCreateRequest req) {
+
+        // 1. 주문자 조회
+        User user = findUser(req);
+
+        // 2. 배송 정보 엔티티 생성
+        OrderDelivery delivery = deliveryInfo(req);
+
+        // 3. 주문 상품(OrderProducts) 리스트 생성
+        List<OrderProducts> orderProductsList = getOrderProductList(req);
+
+        // 예: ORD20240414-a1b2c3d4
+        // 토스 페이먼츠에서 단순히 orderId로 1,2,3 증가하는 형식이면 안된다.
+        //제약 사항: 영문 대소문자, 숫자, 특수문자(-, _)를 포함한 6자 이상 64자 이하의 문자열이어야 한다.
+        String orderNumber = "ORD-" + LocalDate.now().toString().replace("-", "")
+                + "-" + UUID.randomUUID().toString().substring(0, 8);
+
+        //최종적으로 주문 생성
+        Order order = Order.createOrder(user, orderNumber, delivery, orderProductsList);
+
+        // 5. 저장
+        // Order 엔티티에 cascade = CascadeType.ALL 설정을 했기 때문에,
+        // order만 save해도 연관된 OrderDelivery와 OrderProducts,Payment가 모두 함께 DB에 저장됩니다.
+        orderRepository.save(order);
+
+        //응답할때 OrderNumber(토스 페이먼츠가 원하는 형식), totalAmout, userId을 돌려준다.
+        return OrderResponse.from(order);
+    }
+
+    //유저 찾기
+    public User findUser(OrderCreateRequest request) {
+        return userRepository.findById(request.user_id())
+                .orElseThrow(() ->new BusinessException(USER_NOT_FOUND,"해당 유저 정보를 찾을 수 없습니다."));
+    }
+
+    //order-delivery 테이블에 배송지, 운송장 번호 생성
+    public OrderDelivery deliveryInfo(OrderCreateRequest request) {
+        return  OrderDelivery.builder()
+                .delivery_address(request.delivery_address())
+                .tracking_number(null) // 송장 번호를 여기서 만들어야 하나?
+                .build();
+    }
+
+    //order-product테이블에 상품id, 상품 수량, 상품 가격을 넣는다.
+    public List<OrderProducts> getOrderProductList(OrderCreateRequest request) {
+        return request.orderProducts().stream()
+                .map(orderProdctReq->{
+                    Product product = productRepository.findById(orderProdctReq.productId())
+                            .orElseThrow(() -> new BusinessException(PRODUCT_NOT_FOUND,"상품을 찾을 수 없습니다. ID: " + orderProdctReq.productId()));
+
+                    //todo 재고 감소 로직
+
+                    //OrderProduct 테이블에 저장
+                    return OrderProducts.builder()
+                            .product(product)
+                            .quantity(orderProdctReq.quantity())
+                            .orderPrice(product.getPrice())
+                            .build();
+                }).toList();
+    }
+
+}

--- a/src/test/java/com/team10/backend/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/order/controller/OrderControllerTest.java
@@ -1,0 +1,171 @@
+package com.team10.backend.domain.order.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team10.backend.domain.order.dto.OrderCreateRequest;
+import com.team10.backend.domain.order.dto.OrderResponse;
+import com.team10.backend.domain.order.service.OrderService;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+public class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 실행 전 실제 DB(H2)에 기초 데이터를 밀어넣습니다.
+        jdbcTemplate.update("DELETE FROM payments");
+        jdbcTemplate.update("DELETE FROM order_products");
+        jdbcTemplate.update("DELETE FROM order_delivery");
+        jdbcTemplate.update("DELETE FROM orders");
+        jdbcTemplate.update("DELETE FROM products");
+        jdbcTemplate.update("DELETE FROM users");
+
+        // 유저 삽입 (ID: 1)
+        jdbcTemplate.update(
+                "INSERT INTO users (id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (1, 'buyer@test.com', '1234', '홍길동', '길동이', '010-1234-5678', '서울시', 'ACTIVE', 'USER', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        );
+
+        // 상품들 삽입 (각각 가격이 다름)
+        jdbcTemplate.update("INSERT INTO products (id, user_id, product_name, price, stock, type, status, created_at, updated_at) VALUES (?, 1, ?, ?, 10, 'BOOK', 'SELLING', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", 101L, "상품A", 10000);
+        jdbcTemplate.update("INSERT INTO products (id, user_id, product_name, price, stock, type, status, created_at, updated_at) VALUES (?, 1, ?, ?, 10, 'BOOK', 'SELLING', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", 102L, "상품B", 20000);
+        jdbcTemplate.update("INSERT INTO products (id, user_id, product_name, price, stock, type, status, created_at, updated_at) VALUES (?, 1, ?, ?, 10, 'BOOK', 'SELLING', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", 103L, "상품C", 30000);
+    }
+
+
+    @Test
+    @DisplayName("주문 생성 성공 - 로직을 통해 합산 금액 검증")
+    void t1_2() throws Exception {
+        // Given: 요청 데이터 준비
+        // 상품101(1만)x2 + 상품102(2만)x2 + 상품103(3만)x2
+        OrderCreateRequest.OrderProductReq item1 = new OrderCreateRequest.OrderProductReq(101L, 2);
+        OrderCreateRequest.OrderProductReq item2 = new OrderCreateRequest.OrderProductReq(102L, 2);
+        OrderCreateRequest.OrderProductReq item3 = new OrderCreateRequest.OrderProductReq(103L, 2);
+
+        // 예상 총 금액: (10000*2) + (20000*2) + (30000*2) = 120,000원
+        int expectedTotalAmount = 120000;
+
+        OrderCreateRequest req = new OrderCreateRequest(1L, "서울특별시 강남구 테헤란로", List.of(item1, item2, item3));
+        System.out.println(orderService.createOrder(req));
+        // When: 호출 (실제 서비스의 createOrder가 실행됨)
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/v1/orders")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(req))
+                )
+                .andDo(print());
+
+        // Then: 검증
+        // 이제 mockResponse가 아니라 실제 서비스가 계산해서 반환한 값이 검증됩니다.
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1L))
+                .andExpect(jsonPath("$.data.totalAmount").value(expectedTotalAmount)) // 실제 계산 결과 검증
+                .andExpect(jsonPath("$.data.orderNumber").exists());
+    }
+
+    @Test
+    @DisplayName("주문 생성 실패 - 필수 입력값 누락 (Validation)")
+    void t2() throws Exception {
+        // Given: 주소가 비어있고 상품이 없는 잘못된 요청
+        OrderCreateRequest req = new OrderCreateRequest(1L, "", List.of());
+
+        // When & Then
+        mvc.perform(
+                        post("/api/v1/orders")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(req))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest()); // @Valid에 의해 400 에러 발생
+    }
+
+    @Test
+    @DisplayName("주문 생성 실패 - 존재하지 않는 상품 (BusinessException)")
+    void t3() throws Exception {
+        OrderCreateRequest.OrderProductReq item = new OrderCreateRequest.OrderProductReq(999L, 1);
+        OrderCreateRequest req = new OrderCreateRequest(1L, "주소", List.of(item));
+
+        // [중요] when(...).thenThrow(...) 코드를 아예 삭제하세요!
+        // 실제 서비스가 실행되면서 productRepository.findById(999L)를 호출하고,
+        // 결과가 없으니 서비스 로직에 작성하신 BusinessException이 자동으로 터집니다.
+
+        // When
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/v1/orders")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(req))
+                )
+                .andDo(print());
+
+        // Then: 서비스가 던진 BusinessException을 ExceptionHandler가 ProblemDetail로 변환했는지 확인
+        resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.PRODUCT_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.detail").value("상품을 찾을 수 없습니다. ID: 999"));
+    }
+
+    @Test
+    @DisplayName("주문 생성 실패 - 존재하지 않는 사용자 (BusinessException)")
+    void t4() throws Exception {
+        // Given: DB에 없는 사용자 ID 999L로 요청
+        Long invalidUserId = 999L;
+        OrderCreateRequest.OrderProductReq item = new OrderCreateRequest.OrderProductReq(101L, 1);
+        OrderCreateRequest req = new OrderCreateRequest(invalidUserId, "서울특별시 강남구", List.of(item));
+
+        // when(...) 삭제!
+        // 서비스의 findUser(req) 내부에서 userRepository.findById(999L)가
+        // 빈 Optional을 반환하여 BusinessException(USER_NOT_FOUND)이 발생.
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/v1/orders")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(req))
+                )
+                .andDo(print());
+
+        // Then
+        resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.detail").value("해당 유저 정보를 찾을 수 없습니다."));
+    }
+}

--- a/src/test/java/com/team10/backend/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/order/controller/OrderControllerTest.java
@@ -59,7 +59,7 @@ public class OrderControllerTest {
         // 유저 삽입 (ID: 1)
         jdbcTemplate.update(
                 "INSERT INTO users (id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
-                        "VALUES (1, 'buyer@test.com', '1234', '홍길동', '길동이', '010-1234-5678', '서울시', 'ACTIVE', 'USER', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                        "VALUES (1, 'buyer@test.com', '1234', '홍길동', '길동이', '010-1234-5678', '서울시', 'ACTIVE', 'BUYER', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
         );
 
         // 상품들 삽입 (각각 가격이 다름)

--- a/src/test/java/com/team10/backend/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/order/service/OrderServiceTest.java
@@ -1,0 +1,107 @@
+package com.team10.backend.domain.order.service;
+
+import com.team10.backend.domain.order.dto.OrderCreateRequest;
+import com.team10.backend.domain.order.dto.OrderResponse;
+import com.team10.backend.domain.order.repository.OrderRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class OrderServiceTest {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        // 1. 기존 데이터 정리 (자식 테이블부터 삭제하여 외래키 제약조건 위반 방지)
+        jdbcTemplate.update("DELETE FROM payments");
+        jdbcTemplate.update("DELETE FROM order_products");
+        jdbcTemplate.update("DELETE FROM order_delivery");
+        jdbcTemplate.update("DELETE FROM orders");
+        jdbcTemplate.update("DELETE FROM products");
+        jdbcTemplate.update("DELETE FROM users");
+
+        // 2. 유저 데이터 삽입 (ID: 1)
+        jdbcTemplate.update(
+                "INSERT INTO users (id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                1L, "buyer@test.com", "1234", "홍길동", "길동이", "010-1234-5678", "서울시 강남구", "ACTIVE", "USER"
+        );
+
+        // 3. 상품 데이터 삽입 (ID: 101, 102)
+        // t1 테스트에서 101번과 102번 상품을 모두 사용하므로 두 개 다 넣어줍니다.
+        jdbcTemplate.update(
+                "INSERT INTO products (id, user_id, product_name, price, stock, type, status, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                101L, 1L, "맥북 프로", 2000000, 10, "BOOK", "SELLING"
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO products (id, user_id, product_name, price, stock, type, status, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                102L, 1L, "매직 마우스", 50000, 20, "BOOK", "SELLING"
+        );
+    }
+
+    @Test
+    @DisplayName("주문 생성 서비스 - 모든 연관 엔티티가 DB에 저장되어야 한다 (Cascade 확인)/ order에 연관된 DB에 값들이 잘 들어가는 지 확인")
+    void t1() {
+        // Given
+        // 아이템 1: 맥북 프로(2,000,000원) x 1 = 2,000,000
+        OrderCreateRequest.OrderProductReq item1 = new OrderCreateRequest.OrderProductReq(101L, 1);
+        // 아이템 2: 매직 마우스(50,000원) x 2 = 100,000
+        OrderCreateRequest.OrderProductReq item2 = new OrderCreateRequest.OrderProductReq(102L, 2);
+
+        OrderCreateRequest req = new OrderCreateRequest(1L, "서울시 강남구 테헤란로", List.of(item1, item2));
+
+        // When
+        OrderResponse response = orderService.createOrder(req);
+
+        // Then 1: 응답 데이터 검증
+        assertThat(response.userId()).isEqualTo(1L);
+        assertThat(response.totalAmount()).isEqualTo(2100000); // 총 합계 210만 원
+        assertThat(response.orderNumber()).startsWith("ORD-");
+
+        // Then 2: DB 저장 상태 상세 검증 (JdbcTemplate 사용)
+
+        // 2-1. Order 테이블 확인
+        Map<String, Object> savedOrder = jdbcTemplate.queryForMap(
+                "SELECT * FROM orders WHERE order_number = ?", response.orderNumber());
+        assertThat(savedOrder.get("total_amount")).isEqualTo(2100000);
+
+        // 2-2. OrderDelivery 테이블 확인
+        Map<String, Object> savedDelivery = jdbcTemplate.queryForMap(
+                "SELECT * FROM order_delivery WHERE order_id = ?", savedOrder.get("id"));
+        assertThat(savedDelivery.get("delivery_address")).isEqualTo("서울시 강남구 테헤란로");
+
+        // 2-3. OrderProducts 테이블 확인
+        Integer productCount = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM order_products WHERE order_id = ?", Integer.class, savedOrder.get("id"));
+        assertThat(productCount).isEqualTo(2);
+
+        // 2-4. Payment 테이블 확인 (엔티티 생성 메서드 내에서 추가된 초기 결제 정보)
+        Map<String, Object> savedPayment = jdbcTemplate.queryForMap(
+                "SELECT * FROM payments WHERE order_id = ?", savedOrder.get("id"));
+
+        // Enum 값 비교 시 DB 저장 형태(String)에 맞춰 대문자로 확인
+        assertThat(savedPayment.get("status").toString()).isEqualTo("READY");
+        assertThat(((Number) savedPayment.get("total_amount")).intValue()).isEqualTo(2100000);
+    }
+}

--- a/src/test/java/com/team10/backend/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/order/service/OrderServiceTest.java
@@ -42,7 +42,7 @@ public class OrderServiceTest {
         jdbcTemplate.update(
                 "INSERT INTO users (id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
                         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-                1L, "buyer@test.com", "1234", "홍길동", "길동이", "010-1234-5678", "서울시 강남구", "ACTIVE", "USER"
+                1L, "buyer@test.com", "1234", "홍길동", "길동이", "010-1234-5678", "서울시 강남구", "ACTIVE", "BUYER"
         );
 
         // 3. 상품 데이터 삽입 (ID: 101, 102)


### PR DESCRIPTION
## 📌 개요 (What)

토스 페이먼츠에서 사용하는 정보에 맞춰서 주문을 생성하는 코드입니다.

## ✨ 작업 내용

- order_delivery , order_products, payment 테이블을 만들어서 request받은 정보를 DB에 넣어 저장합니다. 
- Order엔티티 내부에서 각 테이블 정보를 묶어서 한번에 주문을 생성합니다.
- OrderNumber은 토스 페이먼츠가 주문을 식별할 수 있는 형태가 따로 있어서 페이먼츠 구조에 맞춰 생성하였습니다.

## 🔥 변경 이유

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

- OrderId는 Order테이블과 연관관계를 맺는 외래키로 사용하고 있고, OrderNumber는 주문 하나에 매칭되는 유일한 값입니다. 
- 재고 감소 로직은 아직 구현되지 않아서 추후, 추가할 예정입니다.
- Payment 엔티티 내부에 completePayment, failPayment는 아직 사용되지 않습니다.

## 🔗 관련 이슈
- close #23
