### PR TITLE
Feat/add feed API and like toggle

### DIFF
--- a/src/main/java/com/team10/backend/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/team10/backend/domain/feed/controller/FeedController.java
@@ -1,4 +1,75 @@
 package com.team10.backend.domain.feed.controller;
 
+import com.team10.backend.domain.feed.dto.CreateFeedRequestDto;
+import com.team10.backend.domain.feed.dto.CreateFeedResponseDto;
+import com.team10.backend.domain.feed.dto.FeedLikeToggleResponseDto;
+import com.team10.backend.domain.feed.dto.FeedListResponseDto;
+import com.team10.backend.domain.feed.service.FeedPostService;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.user.repository.UserRepository;
+import com.team10.backend.global.dto.ApiResponse;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/stores")
+@RequiredArgsConstructor
+@Tag(name = "Feed", description = "피드 관리 API")
 public class FeedController {
+
+    private final FeedPostService feedPostService;
+    private final UserRepository userRepository;
+
+    @GetMapping("/{sellerId}/feeds")
+    @Operation(summary = "피드 조회", description = "피드 전체 조회 합니다.")
+    public ApiResponse<FeedListResponseDto> getStoreFeeds(
+            @PathVariable Long sellerId,
+            @AuthenticationPrincipal User currentUser
+    ) {
+        FeedListResponseDto response = feedPostService.getFeedsList(sellerId, currentUser);
+        return ApiResponse.ok(response);
+    }
+
+    @PostMapping("me/feeds")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "피드 생성", description = "판매자가 피드를 생성 합니다.")
+    public ApiResponse<CreateFeedResponseDto> createFeed(
+            @RequestBody CreateFeedRequestDto requestDto
+            //@AuthenticationPrincipal User seller 로그인 후 확인
+    ) {
+        User seller = userRepository.findById(1L)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        CreateFeedResponseDto responseDto = feedPostService.createFeed(requestDto, seller);
+        return ApiResponse.ok(responseDto);
+    }
+
+    @PostMapping("{sellerId}/feeds/{feedId}/like")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "피드 좋아요", description = "사용자가 피드에 좋아요를 누릅니다.")
+    public ApiResponse<FeedLikeToggleResponseDto> toggleFeedLike(
+            @PathVariable Long sellerId,
+            @PathVariable Long feedId
+            //@AuthenticationPrincipal User buyer 로그인 후 확인
+    ) {
+        User currentUser = userRepository.findById(2L)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        FeedLikeToggleResponseDto responseDto =
+                feedPostService.toggleFeedLike(sellerId, feedId, currentUser);
+
+        return ApiResponse.ok(responseDto);
+    }
 }

--- a/src/main/java/com/team10/backend/domain/feed/dto/CreateFeedRequestDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/CreateFeedRequestDto.java
@@ -1,0 +1,16 @@
+package com.team10.backend.domain.feed.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CreateFeedRequestDto(
+        @NotBlank(message = "피드 내용은 필수입니다.")
+        @Size(min = 1, max = 2000, message = "내용은 1자 이상 2,000자 이하로 입력해주세요.")
+        String content,
+
+        @Size(max = 10, message = "미디어 파일은 최대 10개까지 업로드 가능합니다.")
+        List<String> mediaUrls
+) {
+}

--- a/src/main/java/com/team10/backend/domain/feed/dto/CreateFeedResponseDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/CreateFeedResponseDto.java
@@ -1,0 +1,21 @@
+package com.team10.backend.domain.feed.dto;
+
+import com.team10.backend.domain.feed.entity.FeedPost;
+
+import java.util.List;
+
+public record CreateFeedResponseDto(
+        Long feedId,
+        String content,
+        List<String> mediaUrls,
+        String createdAt
+) {
+    public static CreateFeedResponseDto from(FeedPost feedPost) {
+        return new CreateFeedResponseDto(
+                feedPost.getId(),
+                feedPost.getContent(),
+                feedPost.getImageUrl() != null ? List.of(feedPost.getImageUrl()) : List.of(),
+                feedPost.getCreatedAt().toString()
+        );
+    }
+}

--- a/src/main/java/com/team10/backend/domain/feed/dto/FeedDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/FeedDto.java
@@ -1,0 +1,31 @@
+package com.team10.backend.domain.feed.dto;
+
+import com.team10.backend.domain.feed.entity.FeedPost;
+
+import java.time.LocalDateTime;
+
+public record FeedDto(
+        Long id,
+        String imageUrl,
+        String content,
+        int likeCount,
+        int commentCount,
+        boolean isLiked,        // 현재 로그인한 유저가 좋아요를 눌렀는지 여부
+        boolean isNotice,       // 공지사항 여부
+        LocalDateTime createdAt
+    ) {
+    public static FeedDto from(FeedPost feed, boolean isLiked) {
+        return new FeedDto(
+                feed.getId(),
+                feed.getImageUrl(),
+                feed.getContent(),
+                feed.getLikeCount(),
+                feed.getCommentCount(),
+                isLiked,
+                false, // 엔티티에 isNotice 필드가 있다면 feed.isNotice()로 변경
+                feed.getCreatedAt()
+        );
+    }
+}
+
+

--- a/src/main/java/com/team10/backend/domain/feed/dto/FeedLikeToggleResponseDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/FeedLikeToggleResponseDto.java
@@ -1,0 +1,8 @@
+package com.team10.backend.domain.feed.dto;
+
+public record FeedLikeToggleResponseDto(
+        boolean isLiked,
+        int likeCount
+) {
+
+}

--- a/src/main/java/com/team10/backend/domain/feed/dto/FeedListResponseDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/FeedListResponseDto.java
@@ -1,0 +1,11 @@
+package com.team10.backend.domain.feed.dto;
+
+import java.util.List;
+
+public record FeedListResponseDto(
+        List<FeedDto> feeds //
+) {
+    public static FeedListResponseDto from(List<FeedDto> feeds) {
+        return new FeedListResponseDto(feeds);
+    }
+}

--- a/src/main/java/com/team10/backend/domain/feed/entity/FeedLike.java
+++ b/src/main/java/com/team10/backend/domain/feed/entity/FeedLike.java
@@ -1,0 +1,28 @@
+package com.team10.backend.domain.feed.entity;
+
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "feed_likes")
+public class FeedLike extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_post_id")
+    private FeedPost feedPost;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public FeedLike(FeedPost feedPost, User user) {
+        this.feedPost = feedPost;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/team10/backend/domain/feed/entity/FeedPost.java
+++ b/src/main/java/com/team10/backend/domain/feed/entity/FeedPost.java
@@ -2,15 +2,19 @@ package com.team10.backend.domain.feed.entity;
 
 import com.team10.backend.domain.user.entity.User;
 import com.team10.backend.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -28,15 +32,37 @@ public class FeedPost extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @OneToMany(mappedBy = "feedPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FeedLike> feedLikes = new ArrayList<>();
+
     private int likeCount = 0;
     private int commentCount = 0;
-    private int reportCount = 0;
 
-    @Builder
     public FeedPost(String imageUrl, String content, User user) {
         this.imageUrl = imageUrl;
         this.content = content;
         this.user = user;
     }
 
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    public void addLike(User user) {
+        this.feedLikes.add(new FeedLike(this, user));
+        increaseLikeCount();
+    }
+
+    public void removeLikeByUserId(Long userId) {
+        boolean removed = this.feedLikes.removeIf(feedLike -> feedLike.getUser().getId().equals(userId));
+        if (removed) {
+            decreaseLikeCount();
+        }
+    }
 }

--- a/src/main/java/com/team10/backend/domain/feed/entity/FeedPostLike.java
+++ b/src/main/java/com/team10/backend/domain/feed/entity/FeedPostLike.java
@@ -1,6 +1,0 @@
-package com.team10.backend.domain.feed.entity;
-
-import com.team10.backend.global.entity.BaseEntity;
-
-public class FeedPostLike extends BaseEntity {
-}

--- a/src/main/java/com/team10/backend/domain/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/team10/backend/domain/feed/repository/FeedLikeRepository.java
@@ -1,0 +1,10 @@
+package com.team10.backend.domain.feed.repository;
+
+import com.team10.backend.domain.feed.entity.FeedLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
+    Optional<FeedLike> findByFeedPostId_AndUser_Id(Long feedPostId, Long userId);
+}

--- a/src/main/java/com/team10/backend/domain/feed/repository/FeedPostRepository.java
+++ b/src/main/java/com/team10/backend/domain/feed/repository/FeedPostRepository.java
@@ -1,0 +1,10 @@
+package com.team10.backend.domain.feed.repository;
+
+import com.team10.backend.domain.feed.entity.FeedPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
+    List<FeedPost> findAllByUserIdOrderByCreatedAtDesc(Long sellerId);
+}

--- a/src/main/java/com/team10/backend/domain/feed/service/FeedPostService.java
+++ b/src/main/java/com/team10/backend/domain/feed/service/FeedPostService.java
@@ -1,0 +1,91 @@
+package com.team10.backend.domain.feed.service;
+
+import com.team10.backend.domain.feed.dto.CreateFeedRequestDto;
+import com.team10.backend.domain.feed.dto.CreateFeedResponseDto;
+import com.team10.backend.domain.feed.dto.FeedDto;
+import com.team10.backend.domain.feed.dto.FeedLikeToggleResponseDto;
+import com.team10.backend.domain.feed.dto.FeedListResponseDto;
+import com.team10.backend.domain.feed.entity.FeedLike;
+import com.team10.backend.domain.feed.entity.FeedPost;
+import com.team10.backend.domain.feed.repository.FeedLikeRepository;
+import com.team10.backend.domain.feed.repository.FeedPostRepository;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedPostService {
+
+    private final FeedPostRepository feedPostRepository;
+    private final FeedLikeRepository feedLikeRepository;
+
+    public FeedListResponseDto getFeedsList(Long sellerId, User currentUser) {
+        List<FeedPost> feedPosts = feedPostRepository.findAllByUserIdOrderByCreatedAtDesc(sellerId);
+
+        if (feedPosts.isEmpty()) {
+            throw new BusinessException(ErrorCode.FEED_NOT_FOUND);
+        }
+
+        List<FeedDto> feedDtos = feedPosts.stream()
+                .map(feed -> {
+                    boolean isLiked = false;
+                    if (currentUser != null) {
+                        isLiked = feed.getFeedLikes().stream()
+                                .anyMatch(like -> like.getUser().getId().equals(currentUser.getId()));
+                    }
+                    return FeedDto.from(feed, isLiked);
+                })
+                .toList();
+
+        return new FeedListResponseDto(feedDtos);
+    }
+
+    @Transactional
+    public CreateFeedResponseDto createFeed(CreateFeedRequestDto requestDto, User currentUser) {
+        FeedPost feedPost = new FeedPost(
+                requestDto.mediaUrls() != null && !requestDto.mediaUrls().isEmpty()
+                    ? requestDto.mediaUrls().getFirst()
+                    : "",
+                requestDto.content(),
+                currentUser
+        );
+
+        FeedPost savedFeed = feedPostRepository.save(feedPost);
+        return CreateFeedResponseDto.from(savedFeed);
+    }
+
+    @Transactional
+    public FeedLikeToggleResponseDto toggleFeedLike(Long sellerId, Long feedId, User currentUser) {
+        if (currentUser == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        FeedPost feedPost = feedPostRepository.findById(feedId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FEED_NOT_FOUND));
+
+        if (!feedPost.getUser().getId().equals(sellerId)) {
+            throw new BusinessException(ErrorCode.FEED_NOT_FOUND);
+        }
+
+        boolean isLiked = feedLikeRepository.findByFeedPostId_AndUser_Id(feedId, currentUser.getId())
+                .map(feedLike -> {
+                    feedLikeRepository.delete(feedLike);
+                    feedPost.decreaseLikeCount();
+                    return false;
+                })
+                .orElseGet(() -> {
+                    feedLikeRepository.save(new FeedLike(feedPost, currentUser));
+                    feedPost.increaseLikeCount();
+                    return true;
+                });
+
+        return new FeedLikeToggleResponseDto(isLiked, feedPost.getLikeCount());
+    }
+}

--- a/src/main/java/com/team10/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/team10/backend/global/exception/ErrorCode.java
@@ -19,7 +19,10 @@ public enum ErrorCode {
 
     // === 상품 도메인 (3000~3999) ===,
     PRODUCT_NOT_FOUND("PRODUCT_001", "상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    INSUFFICIENT_STOCK("PRODUCT_002", "재고가 부족합니다.", HttpStatus.BAD_REQUEST);
+    INSUFFICIENT_STOCK("PRODUCT_002", "재고가 부족합니다.", HttpStatus.BAD_REQUEST),
+
+    // === 피드 도메인 (4000~4999) ===
+    FEED_NOT_FOUND("FEED_001", "피드를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;        // 프론트에서 분기용 비즈니스 코드
     private final String message;     // 기본 메시지 (상세 설명은 동적 생성 가능)

--- a/src/test/java/com/team10/backend/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/feed/controller/FeedControllerTest.java
@@ -1,0 +1,152 @@
+package com.team10.backend.domain.feed.controller;
+
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.feed.repository.FeedPostRepository;
+import com.team10.backend.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@AutoConfigureMockMvc(addFilters = false)
+public class FeedControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private FeedPostRepository feedPostRepository;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM feed_likes");
+        jdbcTemplate.update("DELETE FROM feed_posts");
+        jdbcTemplate.update("DELETE FROM users");
+
+        jdbcTemplate.update(
+                "INSERT INTO users " +
+                        "(id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                1L,
+                "seller@test.com",
+                "1234",
+                "테스트판매자",
+                "seller1",
+                "010-1234-5678",
+                "서초구",
+                "ACTIVE",
+                "SELLER"
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO users " +
+                        "(id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                2L,
+                "user@test.com",
+                "1234",
+                "일반유저",
+                "user1",
+                "010-9876-5432",
+                "강남구",
+                "ACTIVE",
+                "BUYER"
+        );
+    }
+
+    @Test
+    @DisplayName("피드 등록 테스트")
+    void createFeed() throws Exception {
+        String requestBody = """
+            {
+              "content": "오늘의 새로운 소식!",
+              "mediaUrls": ["https://image.url/1"]
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/stores/me/feeds")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated()) // 201 확인
+                .andExpect(jsonPath("$.data.content").value("오늘의 새로운 소식!"));
+    }
+
+    @Test
+    @DisplayName("피드 전체 목록 조회 (최신순)")
+    void getFeeds() throws Exception {
+        jdbcTemplate.update(
+                "INSERT INTO feed_posts (image_url, content, user_id, like_count, comment_count, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                "https://test.com/image.jpg", // imageUrl
+                "조회 테스트용 피드입니다",        // content
+                1L,                            // user_id
+                0,                             // likeCount
+                0                              // commentCount
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO feed_posts (image_url, content, user_id, like_count, comment_count, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                "https://test.com/image.jpg", // imageUrl
+                "조회 테스트용 피드2입니다",        // content
+                1L,                            // user_id
+                0,                             // likeCount
+                0                              // commentCount
+        );
+
+        mockMvc.perform(get("/api/v1/stores/1/feeds")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.feeds[0].content").value("조회 테스트용 피드2입니다"))
+                .andExpect(jsonPath("$.data.feeds[1].content").value("조회 테스트용 피드입니다"));
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 토글 테스트")
+    void toggleFeedLike() throws Exception {
+        jdbcTemplate.update(
+                "INSERT INTO feed_posts (id, image_url, content, user_id, like_count, comment_count, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                100L,
+                "https://test.com/image.jpg",
+                "좋아요 테스트용 피드",
+                1L,
+                0,
+                0
+        );
+
+        User currentUser = userRepository.findById(2L).orElseThrow();
+
+        mockMvc.perform(post("/api/v1/stores/1/feeds/100/like")
+                        .with(authentication(new TestingAuthenticationToken(currentUser, null)))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.isLiked").value(true))
+                .andExpect(jsonPath("$.data.likeCount").value(1));
+    }
+}

--- a/src/test/java/com/team10/backend/domain/feed/service/FeedPostServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/feed/service/FeedPostServiceTest.java
@@ -1,0 +1,223 @@
+package com.team10.backend.domain.feed.service;
+
+import com.team10.backend.domain.feed.dto.CreateFeedRequestDto;
+import com.team10.backend.domain.feed.dto.CreateFeedResponseDto;
+import com.team10.backend.domain.feed.dto.FeedLikeToggleResponseDto;
+import com.team10.backend.domain.feed.dto.FeedListResponseDto;
+import com.team10.backend.domain.feed.repository.FeedLikeRepository;
+import com.team10.backend.domain.feed.repository.FeedPostRepository;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.user.repository.UserRepository;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@AutoConfigureMockMvc(addFilters = false)
+public class FeedPostServiceTest {
+
+    @Autowired
+    private FeedPostRepository feedPostRepository;
+
+    @Autowired
+    private FeedLikeRepository feedLikeRepository;
+
+    @Autowired
+    private FeedPostService feedPostService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private User testUser;
+    private User buyerUser;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM feed_likes");
+        jdbcTemplate.update("DELETE FROM feed_posts");
+        jdbcTemplate.update("DELETE FROM users");
+
+        jdbcTemplate.update(
+                "INSERT INTO users " +
+                        "(id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                1L,
+                "seller@test.com",
+                "1234",
+                "테스트판매자",
+                "seller1",
+                "010-1234-5678",
+                "서울시",
+                "ACTIVE",
+                "SELLER"
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO users " +
+                        "(id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                2L,
+                "buyer@test.com",
+                "1234",
+                "테스트구매자",
+                "buyer1",
+                "010-9999-9999",
+                "서울시",
+                "ACTIVE",
+                "BUYER"
+        );
+
+        testUser = userRepository.findById(1L).orElseThrow();
+        buyerUser = userRepository.findById(2L).orElseThrow();
+    }
+
+    @Test
+    @DisplayName("피드 목록 조회 - 성공 (좋아요 여부 포함)")
+    void getFeedsList_success() {
+        // given
+        Long sellerId = 1L;
+        jdbcTemplate.update(
+                "INSERT INTO feed_posts (image_url, content, user_id, like_count, comment_count, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                "https://test.com/image.jpg",
+                "테스트 내용",
+                sellerId,
+                0,
+                0
+        );
+
+        // when
+        FeedListResponseDto result = feedPostService.getFeedsList(sellerId, testUser);
+
+        // then
+        assertThat(result.feeds()).hasSize(1);
+        assertThat(result.feeds().get(0).content()).isEqualTo("테스트 내용");
+    }
+
+    @Test
+    @DisplayName("피드 목록 조회 - 데이터 없음 (예외 발생)")
+    void getFeedsList_notFound() {
+
+        Long sellerId = 1L;
+
+        assertThatThrownBy(() -> feedPostService.getFeedsList(sellerId, testUser))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.FEED_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("피드 생성 - 성공")
+    void createFeed_success() {
+
+        CreateFeedRequestDto requestDto = new CreateFeedRequestDto(
+                "테스트 피드 내용입니다.",
+                List.of("https://test-image.com")
+        );
+
+
+        CreateFeedResponseDto result = feedPostService.createFeed(requestDto, testUser);
+
+
+        assertThat(result.feedId()).isNotNull();
+        assertThat(result.content()).isEqualTo("테스트 피드 내용입니다.");
+        assertThat(result.mediaUrls().get(0)).isEqualTo("https://test-image.com");
+        assertThat(feedPostRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 토글 - 좋아요 추가 성공")
+    void toggleFeedLike_success() {
+        jdbcTemplate.update(
+                "INSERT INTO feed_posts (id, image_url, content, user_id, like_count, comment_count, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                100L,
+                "https://test.com/image.jpg",
+                "좋아요 테스트용 피드",
+                1L,
+                0,
+                0
+        );
+
+        FeedLikeToggleResponseDto result = feedPostService.toggleFeedLike(1L, 100L, buyerUser);
+        feedLikeRepository.flush();
+        feedPostRepository.flush();
+
+        Integer likeCount = jdbcTemplate.queryForObject(
+                "SELECT like_count FROM feed_posts WHERE id = ?",
+                Integer.class,
+                100L
+        );
+        Integer feedLikeCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_likes WHERE feed_post_id = ? AND user_id = ?",
+                Integer.class,
+                100L,
+                2L
+        );
+
+        assertThat(result.isLiked()).isTrue();
+        assertThat(result.likeCount()).isEqualTo(1);
+        assertThat(likeCount).isEqualTo(1);
+        assertThat(feedLikeCount).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 토글 - 좋아요 취소 성공")
+    void toggleFeedLike_cancelSuccess() {
+        jdbcTemplate.update(
+                "INSERT INTO feed_posts (id, image_url, content, user_id, like_count, comment_count, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                101L,
+                "https://test.com/image.jpg",
+                "좋아요 취소 테스트용 피드",
+                1L,
+                1,
+                0
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO feed_likes (feed_post_id, user_id, created_at, updated_at) " +
+                        "VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                101L,
+                2L
+        );
+
+        FeedLikeToggleResponseDto result = feedPostService.toggleFeedLike(1L, 101L, buyerUser);
+        feedLikeRepository.flush();
+        feedPostRepository.flush();
+
+        Integer likeCount = jdbcTemplate.queryForObject(
+                "SELECT like_count FROM feed_posts WHERE id = ?",
+                Integer.class,
+                101L
+        );
+        Integer feedLikeCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_likes WHERE feed_post_id = ? AND user_id = ?",
+                Integer.class,
+                101L,
+                2L
+        );
+
+        assertThat(result.isLiked()).isFalse();
+        assertThat(result.likeCount()).isEqualTo(0);
+        assertThat(likeCount).isEqualTo(0);
+        assertThat(feedLikeCount).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 📌 개요 (What)
- 피드 조회, 생성, 좋아요 토글 기능을 구현하고 관련 서비스/컨트롤러 테스트 추가

## ✨ 작업 내용
- 피드 조회 API 구현
- 피드 생성 API 구현
- 피드 좋아요 토글 API 구현
- 피드 관련 DTO, 엔티티, 레포지토리, 서비스 추가 및 정리
- FeedControllerTest, FeedPostServiceTest 작성

## 🔥 변경 이유

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
- 현재 피드 생성/좋아요는 로그인 연동 전이라 컨트롤러에서 임시로 사용자 조회를 하드코딩한 상태
- 이후 인증 연결 시 @AuthenticationPrincipal 기반으로 교체가 필요

## 🔗 관련 이슈
- close #4
