### PR TITLE
feat: 상품 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
@@ -1,13 +1,9 @@
 package com.team10.backend.domain.product.controller;
 
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
-import com.team10.backend.domain.product.dto.ProductResponse;
+import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.service.ProductService;
-import com.team10.backend.domain.user.entity.User;
-import com.team10.backend.domain.user.repository.UserRepository;
 import com.team10.backend.global.dto.ApiResponse;
-import com.team10.backend.global.exception.BusinessException;
-import com.team10.backend.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -25,19 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "상품 관리", description = "상품 등록/수정/삭제 API")
 public class ProductCommandController {
 
-    private final UserRepository userRepository;
     private final ProductService productService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "상품 등록", description = "판매자가 신규 상품을 등록합니다.")
-    public ApiResponse<ProductResponse> create(@RequestBody @Valid ProductCreateRequest request) {
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        ProductResponse response = productService.create(user, request);
-        return ApiResponse.ok(response);
+    public ApiResponse<ProductDetailResponse> create(@RequestBody @Valid ProductCreateRequest request) {
+        return ApiResponse.ok(productService.create(1L, request));
     }
-
-
 }

--- a/src/main/java/com/team10/backend/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductQueryController.java
@@ -1,5 +1,6 @@
 package com.team10.backend.domain.product.controller;
 
+import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.dto.ProductPageResponse;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +34,11 @@ public class ProductQueryController {
     ) {
         ProductPageResponse response = productService.list(page, size, type, status);
         return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/{productId}")
+    @Operation(summary = "상품 상세 조회", description = "상품 ID로 특정 상품의 상세 정보를 조회합니다.")
+    public ApiResponse<ProductDetailResponse> detail(@PathVariable Long productId) {
+        return ApiResponse.ok(productService.detail(productId));
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductDetailResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductDetailResponse.java
@@ -4,7 +4,7 @@ import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
 
-public record ProductResponse(
+public record ProductDetailResponse(
         Long productId,
         String productName,
         String description,
@@ -14,8 +14,8 @@ public record ProductResponse(
         ProductType type,
         ProductStatus status
 ) {
-    public static ProductResponse from(Product product) {
-        return new ProductResponse(
+    public static ProductDetailResponse from(Product product) {
+        return new ProductDetailResponse(
                 product.getId(),
                 product.getProductName(),
                 product.getDescription(),

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductListResponse.java
@@ -1,0 +1,25 @@
+package com.team10.backend.domain.product.dto;
+
+import com.team10.backend.domain.product.entity.Product;
+import com.team10.backend.domain.product.enums.ProductStatus;
+import com.team10.backend.domain.product.enums.ProductType;
+
+public record ProductListResponse(
+        Long productId,
+        String productName,
+        int price,
+        String imageUrl,
+        ProductType type,
+        ProductStatus status
+) {
+    public static ProductListResponse from(Product product) {
+        return new ProductListResponse(
+                product.getId(),
+                product.getProductName(),
+                product.getPrice(),
+                product.getImageUrl(),
+                product.getType(),
+                product.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductPageResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductPageResponse.java
@@ -3,7 +3,7 @@ package com.team10.backend.domain.product.dto;
 import java.util.List;
 
 public record ProductPageResponse(
-        List<ProductResponse> content,
+        List<ProductListResponse> content,
         int page,
         int size,
         long totalElements,

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -1,13 +1,17 @@
 package com.team10.backend.domain.product.service;
 
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
+import com.team10.backend.domain.product.dto.ProductDetailResponse;
+import com.team10.backend.domain.product.dto.ProductListResponse;
 import com.team10.backend.domain.product.dto.ProductPageResponse;
-import com.team10.backend.domain.product.dto.ProductResponse;
 import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
 import com.team10.backend.domain.product.repository.ProductRepository;
 import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.user.repository.UserRepository;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -22,10 +26,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProductService {
 
+    private final UserRepository userRepository;
     private final ProductRepository productRepository;
 
     @Transactional
-    public ProductResponse create(User user, ProductCreateRequest request) {
+    public ProductDetailResponse create(Long userId, ProductCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
         Product product = new Product(
                 user,
                 request.type(),
@@ -37,7 +45,7 @@ public class ProductService {
         );
 
         Product savedProduct = productRepository.save(product);
-        return ProductResponse.from(savedProduct);
+        return ProductDetailResponse.from(savedProduct);
     }
 
     @Transactional(readOnly = true)
@@ -53,9 +61,9 @@ public class ProductService {
         else productPage = productRepository.findAll(pageable);
 
 
-        List<ProductResponse> content = productPage.getContent()
+        List<ProductListResponse> content = productPage.getContent()
                 .stream()
-                .map(ProductResponse::from)
+                .map(ProductListResponse::from)
                 .toList();
 
         return new ProductPageResponse(
@@ -65,5 +73,12 @@ public class ProductService {
                 productPage.getTotalElements(),
                 productPage.getTotalPages()
         );
+    }
+
+    public ProductDetailResponse detail(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        return ProductDetailResponse.from(product);
     }
 }

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -1,14 +1,16 @@
 package com.team10.backend.domain.product.service;
 
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
+import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.dto.ProductPageResponse;
-import com.team10.backend.domain.product.dto.ProductResponse;
 import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
 import com.team10.backend.domain.product.repository.ProductRepository;
 import com.team10.backend.domain.user.entity.User;
 import com.team10.backend.domain.user.repository.UserRepository;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
@@ -61,10 +64,9 @@ class ProductServiceTest {
     @Test
     @DisplayName("상품 생성 시 SELLING 상태")
     void createProduct_defaultStatusSelling() {
-        User user = userRepository.findById(1L).orElseThrow();
-
         ProductCreateRequest request = new ProductCreateRequest("ABC", "책 설명입니다.", 10000, 100, null, ProductType.BOOK);
-        ProductResponse response = productService.create(user, request);
+
+        ProductDetailResponse response = productService.create(1L, request);
 
         assertThat(response.productId()).isNotNull();
         assertThat(response.productName()).isEqualTo("ABC");
@@ -146,5 +148,40 @@ class ProductServiceTest {
         assertThat(response.content().get(0).productName()).isEqualTo("책1");
         assertThat(response.content().get(0).type()).isEqualTo(ProductType.BOOK);
         assertThat(response.content().get(0).status()).isEqualTo(ProductStatus.SELLING);
+    }
+
+    @Test
+    @DisplayName("상품 상세 조회 성공")
+    void detail_success() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "ABC",
+                "책 설명입니다.",
+                10000,
+                100,
+                null
+        ));
+
+        ProductDetailResponse response = productService.detail(savedProduct.getId());
+
+        assertThat(response.productId()).isEqualTo(savedProduct.getId());
+        assertThat(response.productName()).isEqualTo("ABC");
+        assertThat(response.description()).isEqualTo("책 설명입니다.");
+        assertThat(response.price()).isEqualTo(10000);
+        assertThat(response.stock()).isEqualTo(100);
+        assertThat(response.type()).isEqualTo(ProductType.BOOK);
+        assertThat(response.imageUrl()).isNull();
+        assertThat(response.status()).isEqualTo(ProductStatus.SELLING);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 상세 조회 시, 예외 발생")
+    void detail_fail_productNotFound() {
+        assertThatThrownBy(() -> productService.detail(9999L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## 📌 개요 (What)
상품 ID 기반 특정 상품의 상세 정보 조회를 구현했습니다.

## ✨ 작업 내용
- 상품 상세 조회 API 구현
- 상품 ID 기준 단건 조회 서비스 로직 추가
- 상품 상세 응답 DTO
- 상품 목록 조회 응답 DTO 분리
- 존재하지 않는 상품 조회 시 예외 처리
- Swagger 문서화
- 테스트 코드 작성

## 🔥 변경 이유
상세 조회 기능 확장을 고려해 상품 목록 조회 응답 DTO와 상세 조회 응답 DTO를 분리했습니다.

## 🧪 테스트
- [ ] 기능 정상 동작 확인
- [ ] 테스트 코드 작성

## 🔗 관련 이슈
- close #25 
