### PR TITLE
feat: 상품 수정 API 구현

### DIFF
--- a/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
@@ -2,6 +2,7 @@ package com.team10.backend.domain.product.controller;
 
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
+import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.service.ProductService;
 import com.team10.backend.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,7 +10,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -26,7 +29,16 @@ public class ProductCommandController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "상품 등록", description = "판매자가 신규 상품을 등록합니다.")
-    public ApiResponse<ProductDetailResponse> create(@RequestBody @Valid ProductCreateRequest request) {
+    public ApiResponse<ProductDetailResponse> create(
+            @RequestBody @Valid ProductCreateRequest request) {
         return ApiResponse.ok(productService.create(1L, request));
+    }
+
+    @PutMapping("/{productId}")
+    @Operation(summary = "상품 수정", description = "판매자가 등록한 상품 정보를 수정합니다.")
+    public ApiResponse<ProductDetailResponse> update(
+            @PathVariable Long productId, @RequestBody @Valid ProductUpdateRequest request
+    ) {
+        return ApiResponse.ok(productService.update(productId, request));
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.team10.backend.domain.product.dto;
+
+import com.team10.backend.domain.product.enums.ProductStatus;
+import com.team10.backend.domain.product.enums.ProductType;
+
+public record ProductUpdateRequest(
+        String productName,
+        String description,
+        int price,
+        int stock,
+        String imageUrl,
+        ProductType type,
+        ProductStatus status
+) {
+}

--- a/src/main/java/com/team10/backend/domain/product/entity/Product.java
+++ b/src/main/java/com/team10/backend/domain/product/entity/Product.java
@@ -64,4 +64,22 @@ public class Product extends BaseEntity {
     public void updateStatus(ProductStatus status) {
         this.status = status;
     }
+
+    public void update(
+            ProductType type,
+            String productName,
+            String description,
+            int price,
+            int stock,
+            String imageUrl,
+            ProductStatus status
+    ) {
+        this.type = type;
+        this.productName = productName;
+        this.description = description;
+        this.price = price;
+        this.stock = stock;
+        this.imageUrl = imageUrl;
+        this.status = status;
+    }
 }

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -4,6 +4,7 @@ import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.dto.ProductListResponse;
 import com.team10.backend.domain.product.dto.ProductPageResponse;
+import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
@@ -31,6 +32,7 @@ public class ProductService {
 
     @Transactional
     public ProductDetailResponse create(Long userId, ProductCreateRequest request) {
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -76,8 +78,29 @@ public class ProductService {
     }
 
     public ProductDetailResponse detail(Long productId) {
+
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        return ProductDetailResponse.from(product);
+    }
+
+    @Transactional
+    public ProductDetailResponse update(Long productId, ProductUpdateRequest request) {
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // TODO: 인증/인가 적용 후 판매자 권한 및 본인 상품 여부 검증 추가
+        product.update(
+                request.type(),
+                request.productName(),
+                request.description(),
+                request.price(),
+                request.stock(),
+                request.imageUrl(),
+                request.status()
+        );
 
         return ProductDetailResponse.from(product);
     }

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
@@ -1,5 +1,7 @@
 package com.team10.backend.domain.product.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
@@ -19,6 +21,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -72,7 +75,7 @@ class ProductCommandControllerTest {
         mockMvc.perform(post("/api/v1/stores/me/products")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
-                .andExpect(status().isCreated()) // 상품 등록 성공 시 201
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.productId").exists())
                 .andExpect(jsonPath("$.data.productName").value("ABC"))
@@ -91,5 +94,57 @@ class ProductCommandControllerTest {
         assertThat(product.getType()).isEqualTo(ProductType.BOOK);
         assertThat(product.getStatus()).isEqualTo(ProductStatus.SELLING);
         assertThat(product.getUser().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("상품 수정")
+    void updateProduct_success() throws Exception {
+        jdbcTemplate.update(
+                "INSERT INTO products " +
+                        "(id, user_id, type, product_name, description, price, stock, image_url, status, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                1L,
+                1L,
+                "BOOK",
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://www.exam.com/oldimg",
+                "SELLING"
+        );
+
+        ProductUpdateRequest request = new ProductUpdateRequest(
+                "ABC 수정본",
+                "상품 수정",
+                12000,
+                80,
+                "https://www.exam.com/bookimg",
+                ProductType.BOOK,
+                ProductStatus.SELLING
+        );
+
+        mockMvc.perform(put("/api/v1/stores/me/products/{productId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.productId").value(1))
+                .andExpect(jsonPath("$.data.productName").value("ABC 수정본"))
+                .andExpect(jsonPath("$.data.description").value("상품 수정"))
+                .andExpect(jsonPath("$.data.price").value(12000))
+                .andExpect(jsonPath("$.data.stock").value(80))
+                .andExpect(jsonPath("$.data.imageUrl").value("https://www.exam.com/bookimg"))
+                .andExpect(jsonPath("$.data.type").value("BOOK"))
+                .andExpect(jsonPath("$.data.status").value("SELLING"));
+
+        Product product = productRepository.findById(1L).orElseThrow();
+        assertThat(product.getProductName()).isEqualTo("ABC 수정본");
+        assertThat(product.getDescription()).isEqualTo("상품 수정");
+        assertThat(product.getPrice()).isEqualTo(12000);
+        assertThat(product.getStock()).isEqualTo(80);
+        assertThat(product.getImageUrl()).isEqualTo("https://www.exam.com/bookimg");
+        assertThat(product.getType()).isEqualTo(ProductType.BOOK);
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.SELLING);
     }
 }

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -3,6 +3,7 @@ package com.team10.backend.domain.product.service;
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.dto.ProductPageResponse;
+import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
@@ -181,6 +182,61 @@ class ProductServiceTest {
     @DisplayName("존재하지 않는 상품 상세 조회 시, 예외 발생")
     void detail_fail_productNotFound() {
         assertThatThrownBy(() -> productService.detail(9999L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("상품 수정 성공")
+    void updateProduct_success() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://example.com/old.jpg"
+        ));
+
+        ProductUpdateRequest request = new ProductUpdateRequest(
+                "수정된 상품명",
+                "수정된 설명",
+                12000,
+                20,
+                "https://example.com/new.jpg",
+                ProductType.EBOOK,
+                ProductStatus.SOLD_OUT
+        );
+
+        ProductDetailResponse response = productService.update(savedProduct.getId(), request);
+
+        assertThat(response.productId()).isEqualTo(savedProduct.getId());
+        assertThat(response.productName()).isEqualTo("수정된 상품명");
+        assertThat(response.description()).isEqualTo("수정된 설명");
+        assertThat(response.price()).isEqualTo(12000);
+        assertThat(response.stock()).isEqualTo(20);
+        assertThat(response.imageUrl()).isEqualTo("https://example.com/new.jpg");
+        assertThat(response.type()).isEqualTo(ProductType.EBOOK);
+        assertThat(response.status()).isEqualTo(ProductStatus.SOLD_OUT);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 수정 시, 예외 발생")
+    void updateProduct_fail_productNotFound() {
+        ProductUpdateRequest request = new ProductUpdateRequest(
+                "수정된 상품명",
+                "수정된 설명",
+                12000,
+                20,
+                "https://example.com/new.jpg",
+                ProductType.BOOK,
+                ProductStatus.SELLING
+        );
+
+        assertThatThrownBy(() -> productService.update(9999L, request))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
     }


### PR DESCRIPTION
## 📌 개요 (What)
판매자가 자신의 스토어에 등록한 상품 정보를 수정할 수 있는 API를 구현했습니다.

## ✨ 작업 내용
- 상품 수정 API 구현
- 상품 수정 요청 DTO 작성
- 상품 엔티티 수정 메서드 추가
- 상품 수정 서비스 로직 구현
- 존재하지 않는 상품 수정 시 예외 처리 추가
- Swagger 문서화
- 서비스 테스트 및 컨트롤러 테스트 작성

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
- 현재 인증/인가 및 본인 상품 여부 검증은 추후 반영 예정입니다.

## 🔗 관련 이슈
- close #29 
