### PR TITLE
feat: 상품 비활성화 API 구현

### DIFF
--- a/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
@@ -2,6 +2,7 @@ package com.team10.backend.domain.product.controller;
 
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
+import com.team10.backend.domain.product.dto.ProductInactiveResponse;
 import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.service.ProductService;
 import com.team10.backend.global.dto.ApiResponse;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -40,5 +42,11 @@ public class ProductCommandController {
             @PathVariable Long productId, @RequestBody @Valid ProductUpdateRequest request
     ) {
         return ApiResponse.ok(productService.update(productId, request));
+    }
+
+    @PatchMapping("/{productId}/inactive")
+    @Operation(summary = "상품 삭제(비활성화)", description = "판매자가 등록한 상품을 삭제합니다.")
+    public ApiResponse<ProductInactiveResponse> inactive(@PathVariable Long productId) {
+        return ApiResponse.ok(productService.inactive(productId));
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductInactiveResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductInactiveResponse.java
@@ -1,0 +1,18 @@
+package com.team10.backend.domain.product.dto;
+
+import com.team10.backend.domain.product.entity.Product;
+import com.team10.backend.domain.product.enums.ProductStatus;
+
+public record ProductInactiveResponse(
+        Long productId,
+        ProductStatus status,
+        String message
+) {
+    public static ProductInactiveResponse from(Product product) {
+        return new ProductInactiveResponse(
+                product.getId(),
+                product.getStatus(),
+                "상품이 삭제되었습니다."
+        );
+    }
+}

--- a/src/main/java/com/team10/backend/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/team10/backend/domain/product/repository/ProductRepository.java
@@ -13,5 +13,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Page<Product> findByStatus(ProductStatus status, Pageable pageable);
 
+    Page<Product> findByStatusNot(ProductStatus status, Pageable pageable);
+
     Page<Product> findByTypeAndStatus(ProductType type, ProductStatus status, Pageable pageable);
 }

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -2,6 +2,7 @@ package com.team10.backend.domain.product.service;
 
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
+import com.team10.backend.domain.product.dto.ProductInactiveResponse;
 import com.team10.backend.domain.product.dto.ProductListResponse;
 import com.team10.backend.domain.product.dto.ProductPageResponse;
 import com.team10.backend.domain.product.dto.ProductUpdateRequest;
@@ -60,8 +61,7 @@ public class ProductService {
         if (type != null && status != null) productPage = productRepository.findByTypeAndStatus(type, status, pageable);
         else if (type != null) productPage = productRepository.findByType(type, pageable);
         else if (status != null) productPage = productRepository.findByStatus(status, pageable);
-        else productPage = productRepository.findAll(pageable);
-
+        else productPage = productRepository.findByStatusNot(ProductStatus.INACTIVE, pageable);
 
         List<ProductListResponse> content = productPage.getContent()
                 .stream()
@@ -81,6 +81,8 @@ public class ProductService {
 
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        if (product.getStatus() == ProductStatus.INACTIVE) throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
 
         return ProductDetailResponse.from(product);
     }
@@ -103,5 +105,19 @@ public class ProductService {
         );
 
         return ProductDetailResponse.from(product);
+    }
+
+    @Transactional
+    public ProductInactiveResponse inactive(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        if (product.getStatus() == ProductStatus.INACTIVE) {
+            throw new BusinessException(ErrorCode.PRODUCT_ALREADY_INACTIVE);
+        }
+
+        product.updateStatus(ProductStatus.INACTIVE);
+
+        return ProductInactiveResponse.from(product);
     }
 }

--- a/src/main/java/com/team10/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/team10/backend/global/exception/ErrorCode.java
@@ -18,9 +18,10 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME("USER_003", "이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
     LOGIN_FAILED("USER_004", "아이디 또는 비밀번호가 일치하지 않습니다.", HttpStatus.NOT_FOUND),
 
-    // === 상품 도메인 (3000~3999) ===,
+    // === 상품 도메인 (3000~3999) ===
     PRODUCT_NOT_FOUND("PRODUCT_001", "상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INSUFFICIENT_STOCK("PRODUCT_002", "재고가 부족합니다.", HttpStatus.BAD_REQUEST),
+    PRODUCT_ALREADY_INACTIVE("PRODUCT_003", "이미 비활성화된 상품입니다.", HttpStatus.CONFLICT),
 
     // === 피드 도메인 (4000~4999) ===
     FEED_NOT_FOUND("FEED_001", "피드를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -147,4 +148,57 @@ class ProductCommandControllerTest {
         assertThat(product.getType()).isEqualTo(ProductType.BOOK);
         assertThat(product.getStatus()).isEqualTo(ProductStatus.SELLING);
     }
+
+    @Test
+    @DisplayName("상품 비활성화")
+    void inactiveProduct_success() throws Exception {
+        jdbcTemplate.update(
+                "INSERT INTO products " +
+                        "(id, user_id, type, product_name, description, price, stock, image_url, status, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                1L,
+                1L,
+                "BOOK",
+                "비활성화 대상 상품",
+                "상품 설명",
+                10000,
+                10,
+                "https://www.exam.com/bookimg",
+                "SELLING"
+        );
+
+        mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/inactive", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.productId").value(1))
+                .andExpect(jsonPath("$.data.status").value("INACTIVE"))
+                .andExpect(jsonPath("$.data.message").value("상품이 삭제되었습니다."));
+
+        Product product = productRepository.findById(1L).orElseThrow();
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.INACTIVE);
+    }
+
+    @Test
+    @DisplayName("이미 비활성화된 상품 재요청 시 409")
+    void inactiveProduct_fail_alreadyInactive() throws Exception {
+        jdbcTemplate.update(
+                "INSERT INTO products " +
+                        "(id, user_id, type, product_name, description, price, stock, image_url, status, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                1L,
+                1L,
+                "BOOK",
+                "이미 비활성화된 상품",
+                "상품 설명",
+                10000,
+                10,
+                "https://www.exam.com/bookimg",
+                "INACTIVE"
+        );
+
+        mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/inactive", 1L))
+                .andExpect(status().isConflict());
+    }
+
+
 }

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -2,6 +2,7 @@ package com.team10.backend.domain.product.service;
 
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
+import com.team10.backend.domain.product.dto.ProductInactiveResponse;
 import com.team10.backend.domain.product.dto.ProductPageResponse;
 import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.entity.Product;
@@ -237,6 +238,61 @@ class ProductServiceTest {
         );
 
         assertThatThrownBy(() -> productService.update(9999L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("상품 비활성화 성공")
+    void inactiveProduct_success() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "비활성화 대상 상품",
+                "상품 설명",
+                10000,
+                10,
+                "https://example.com/book.jpg"
+        ));
+
+        ProductInactiveResponse response = productService.inactive(savedProduct.getId());
+
+        assertThat(response.productId()).isEqualTo(savedProduct.getId());
+        assertThat(response.status()).isEqualTo(ProductStatus.INACTIVE);
+        assertThat(response.message()).isEqualTo("상품이 삭제되었습니다.");
+
+        Product product = productRepository.findById(savedProduct.getId()).orElseThrow();
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.INACTIVE);
+    }
+
+    @Test
+    @DisplayName("이미 비활성화된 상품 재요청 시 예외 발생")
+    void inactiveProduct_fail_alreadyInactive() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "이미 비활성화된 상품",
+                "상품 설명",
+                10000,
+                10,
+                "https://example.com/book.jpg"
+        ));
+
+        savedProduct.updateStatus(ProductStatus.INACTIVE);
+
+        assertThatThrownBy(() -> productService.inactive(savedProduct.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.PRODUCT_ALREADY_INACTIVE.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 비활성화 시, 예외 발생")
+    void inactiveProduct_fail_productNotFound() {
+        assertThatThrownBy(() -> productService.inactive(9999L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
     }


### PR DESCRIPTION
## 📌 개요 (What)
판매자가 자신의 스토어에 등록한 상품을 실제 삭제하지 않고, 'INACTIVE' 상태로 변경하는 상품 비활성화 API를 구현했습니다.
그리고 비활성화된 상품이 사용자 화면에 노출되지 않도록 상품 목록 조회 및 상세 조회 로직도 함께 보완했습니다.

## ✨ 작업 내용
- 상품 비활성화 API 구현
- 상품 비활성화 응답 DTO 작성
- 상품 상태를 'INACTIVE'로 변경하는 서비스 로직 구현
- 이미 비활성화된 상품 재요청 시 '409 Conflict' 예외 처리 추가
- 'ErrorCode'에 'PRODUCT_ALREADY_INACTIVE' 추가
- 상품 상세 조회 시, 'INACTIVE' 상품 접근 차단
- 상품 목록 조회에서 'INACTIVE' 상품 제외 처리
- Swagger 문서화
- 서비스 테스트 및 컨트롤러 테스트 작성

## 🧪 테스트
- [ ] 기능 정상 동작 확인
- [ ] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
- 상품 삭제는 실제 삭제가 아닌 'INACTIVE' 상태 변경 방식으로 처리됩니다.
- 일반 상품 목록 조회 및 상세 조회에서는 'INACTIVE' 상품이 노출되지 않도록 처리했습니다.

## 🔗 관련 이슈
- close #31 
