### PR TITLE
feat: JWT 인증 필터 구현

### DIFF
--- a/src/main/java/com/team10/backend/domain/user/enums/Role.java
+++ b/src/main/java/com/team10/backend/domain/user/enums/Role.java
@@ -1,6 +1,6 @@
 package com.team10.backend.domain.user.enums;
 
 public enum Role {
-    BUYER,
-    SELLER
+    ROLE_BUYER,
+    ROLE_SELLER
 }

--- a/src/main/java/com/team10/backend/domain/user/enums/Role.java
+++ b/src/main/java/com/team10/backend/domain/user/enums/Role.java
@@ -1,6 +1,6 @@
 package com.team10.backend.domain.user.enums;
 
 public enum Role {
-    ROLE_BUYER,
-    ROLE_SELLER
+    BUYER,
+    SELLER
 }

--- a/src/main/java/com/team10/backend/global/exception/ErrorResponseUtil.java
+++ b/src/main/java/com/team10/backend/global/exception/ErrorResponseUtil.java
@@ -1,0 +1,27 @@
+package com.team10.backend.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+
+public class ErrorResponseUtil {
+
+    public static ProblemDetail buildProblemDetail(
+            HttpStatus status,
+            String errorCode,
+            String message,
+            HttpServletRequest request
+    ) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(status, message);
+        problem.setTitle(status.getReasonPhrase());
+        problem.setType(URI.create("https://api.example.com/errors/" + errorCode));
+        problem.setProperty("errorCode", errorCode);
+        problem.setProperty("instance", request.getRequestURI());
+        problem.setProperty("timestamp", LocalDateTime.now());
+        return problem;
+    }
+
+}

--- a/src/main/java/com/team10/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team10/backend/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package com.team10.backend.global.security;
+
+import com.team10.backend.global.util.CookieUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final CookieUtil cookieUtil;
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException
+    {
+        // 쿠키 확인
+        String token = cookieUtil.getCookieValue(request,"accessToken");
+
+        if(token == null || token.isBlank()) {
+           filterChain.doFilter(request, response);
+           return;
+        }
+
+        try {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (ExpiredJwtException e) {
+            log.debug("JWT expired");
+        } catch (JwtException e) {
+            log.warn("Invalid JWT");
+        } catch (Exception e) {
+            log.error("Unexpected error in JWT filter", e);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/team10/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/team10/backend/global/security/SecurityConfig.java
@@ -1,16 +1,21 @@
 package com.team10.backend.global.security;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -23,7 +28,33 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .headers((headers) -> headers
                         .addHeaderWriter(new XFrameOptionsHeaderWriter(
-                                XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)));
+                                XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(
+                        exceptionHandling -> exceptionHandling
+                                .authenticationEntryPoint((request, response, authenticationException) -> {
+                                    response.setContentType("application/json; charset=UTF-8");
+                                    response.setStatus(401);
+                                    response.getWriter().write(
+                                                """
+                                                        {
+                                                            "code": "401",
+                                                            "message": "로그인 후 이용해주세요."
+                                                        }
+                                                    """);
+                                })
+                                .accessDeniedHandler((request, response, accessDeniedException) -> {
+                                            response.setContentType("application/json; charset=UTF-8");
+                                            response.setStatus(403);
+                                            response.getWriter().write(
+                                                """
+                                                        {
+                                                            "code": "403",
+                                                            "message": "접근 권한이 없습니다."
+                                                        }
+                                                    """);
+                                        }
+                                ));
 
         return http.build();
     }

--- a/src/main/java/com/team10/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/team10/backend/global/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
                         .requestMatchers("/favicon.ico").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
                 .csrf(AbstractHttpConfigurer::disable)
                 .headers((headers) -> headers

--- a/src/main/java/com/team10/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/team10/backend/global/security/SecurityConfig.java
@@ -1,14 +1,18 @@
 package com.team10.backend.global.security;
 
+import com.team10.backend.global.exception.ErrorResponseUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
+import tools.jackson.databind.ObjectMapper;
 
 @Configuration
 @EnableWebSecurity
@@ -16,6 +20,7 @@ import org.springframework.security.web.header.writers.frameoptions.XFrameOption
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ObjectMapper objectMapper;
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -23,38 +28,37 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
                         .requestMatchers("/favicon.ico").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
                 )
                 .csrf(AbstractHttpConfigurer::disable)
                 .headers((headers) -> headers
                         .addHeaderWriter(new XFrameOptionsHeaderWriter(
                                 XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .exceptionHandling(
-                        exceptionHandling -> exceptionHandling
-                                .authenticationEntryPoint((request, response, authenticationException) -> {
-                                    response.setContentType("application/json; charset=UTF-8");
-                                    response.setStatus(401);
-                                    response.getWriter().write(
-                                                """
-                                                        {
-                                                            "code": "401",
-                                                            "message": "로그인 후 이용해주세요."
-                                                        }
-                                                    """);
-                                })
-                                .accessDeniedHandler((request, response, accessDeniedException) -> {
-                                            response.setContentType("application/json; charset=UTF-8");
-                                            response.setStatus(403);
-                                            response.getWriter().write(
-                                                """
-                                                        {
-                                                            "code": "403",
-                                                            "message": "접근 권한이 없습니다."
-                                                        }
-                                                    """);
-                                        }
-                                ));
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setContentType("application/json; charset=UTF-8");
+                            response.setStatus(401);
+                            ProblemDetail problem = ErrorResponseUtil.buildProblemDetail(
+                                    HttpStatus.UNAUTHORIZED,
+                                    "UNAUTHORIZED",
+                                    "인증 정보가 없습니다.",
+                                    request
+                            );
+                            response.getWriter().write(objectMapper.writeValueAsString(problem));
+                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.setContentType("application/json; charset=UTF-8");
+                            response.setStatus(403);
+                            ProblemDetail problem = ErrorResponseUtil.buildProblemDetail(
+                                    HttpStatus.FORBIDDEN,
+                                    "FORBIDDEN",
+                                    "접근 권한이 없습니다.",
+                                    request
+                            );
+                            response.getWriter().write(objectMapper.writeValueAsString(problem));
+                        })
+                );
 
         return http.build();
     }

--- a/src/main/java/com/team10/backend/global/security/TokenProvider.java
+++ b/src/main/java/com/team10/backend/global/security/TokenProvider.java
@@ -1,12 +1,19 @@
 package com.team10.backend.global.security;
 
 import com.team10.backend.domain.user.enums.Role;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
+import java.util.List;
 
 public class TokenProvider {
 
@@ -36,5 +43,29 @@ public class TokenProvider {
         return new Date(issuedAt.getTime() + expireTime * 1000 * 60);
     }
 
+    public Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
 
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        String userId = claims.getSubject();
+        String role = claims.get("role", String.class);
+
+        UserDetails userDetails = new User(
+                userId,
+                null,
+                List.of(new SimpleGrantedAuthority(role))
+        );
+
+        return new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
+    }
 }

--- a/src/main/java/com/team10/backend/global/security/TokenProvider.java
+++ b/src/main/java/com/team10/backend/global/security/TokenProvider.java
@@ -59,7 +59,7 @@ public class TokenProvider {
         UserDetails userDetails = new User(
                 userId,
                 null,
-                List.of(new SimpleGrantedAuthority(role))
+                List.of(new SimpleGrantedAuthority("ROLE_" + role))
         );
 
         return new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/team10/backend/global/util/CookieUtil.java
+++ b/src/main/java/com/team10/backend/global/util/CookieUtil.java
@@ -1,6 +1,7 @@
 package com.team10.backend.global.util;
 
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,20 @@ public class CookieUtil {
         cookie.setAttribute("SameSite", "Strict");
 
         response.addCookie(cookie);
+    }
+
+    public String getCookieValue(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) return null;
+
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(name)) {
+                return cookie.getValue();
+            }
+        }
+
+        return null;
     }
 
 }

--- a/src/test/java/com/team10/backend/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/order/service/OrderServiceTest.java
@@ -2,7 +2,6 @@ package com.team10.backend.domain.order.service;
 
 import com.team10.backend.domain.order.dto.OrderCreateRequest;
 import com.team10.backend.domain.order.dto.OrderResponse;
-import com.team10.backend.domain.order.repository.OrderRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/team10/backend/global/security/TokenProviderTest.java
+++ b/src/test/java/com/team10/backend/global/security/TokenProviderTest.java
@@ -8,12 +8,16 @@ import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
 
 import javax.crypto.SecretKey;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TokenProviderTest {
 
@@ -36,7 +40,7 @@ public class TokenProviderTest {
     void generateToken_success() {
         // given
         Long userId = 1L;
-        Role role = Role.ROLE_BUYER;
+        Role role = Role.BUYER;
 
         // when
         String token = tokenProvider.generateToken(userId, role);
@@ -50,7 +54,7 @@ public class TokenProviderTest {
     @DisplayName("토큰에 id와 role이 포함된다")
     void token_contains_claims() {
         // given
-        String token = tokenProvider.generateToken(1L, Role.ROLE_BUYER);
+        String token = tokenProvider.generateToken(1L, Role.BUYER);
 
         // when
         Claims claims = Jwts.parser()
@@ -62,6 +66,64 @@ public class TokenProviderTest {
         // then
         assertEquals("1", claims.getSubject());
         assertEquals("BUYER", claims.get("role").toString());
+    }
+
+    @Test
+    @DisplayName("토큰 파싱이 정상적으로 된다")
+    void parseClaims_success() {
+        // given
+        String token = tokenProvider.generateToken(1L, Role.BUYER);
+
+        // when
+        Claims claims = tokenProvider.parseClaims(token);
+
+        // then
+        assertEquals("1", claims.getSubject());
+        assertEquals("BUYER", claims.get("role"));
+    }
+
+    @Test
+    @DisplayName("Authentication 객체가 정상 생성되고 권한 정보가 제대로 들어간다")
+    void getAuthentication_success() {
+        // given
+        String token = tokenProvider.generateToken(1L, Role.BUYER);
+
+        // when
+        Authentication authentication = tokenProvider.getAuthentication(token);
+
+        // then
+        assertNotNull(authentication);
+        assertEquals("1", authentication.getName());
+        assertEquals(1, authentication.getAuthorities().size());
+        assertTrue(
+                authentication.getAuthorities().stream()
+                        .anyMatch(a ->
+                                Objects.equals(a.getAuthority(), "ROLE_BUYER")));
+    }
+
+//    @Test
+//    @DisplayName("시간이 만료된 토큰은 예외가 발생한다")
+//    void parseClaims_fail_expireToken() throws InterruptedException {
+//        String token = tokenProvider.generateToken(1L, Role.BUYER);
+//
+//        Thread.sleep(60001);
+//
+//        // when & then
+//        assertThrows(ExpiredJwtException.class, () -> {
+//            tokenProvider.parseClaims(token);
+//        });
+//    }
+
+    @Test
+    @DisplayName("잘못된 토큰은 예외가 발생한다")
+    void parseClaims_fail() {
+        // given
+        String invalidToken = "fake.token.value";
+
+        // when & then
+        assertThrows(Exception.class, () -> {
+            tokenProvider.parseClaims(invalidToken);
+        });
     }
 
 }

--- a/src/test/java/com/team10/backend/global/security/TokenProviderTest.java
+++ b/src/test/java/com/team10/backend/global/security/TokenProviderTest.java
@@ -36,7 +36,7 @@ public class TokenProviderTest {
     void generateToken_success() {
         // given
         Long userId = 1L;
-        Role role = Role.BUYER;
+        Role role = Role.ROLE_BUYER;
 
         // when
         String token = tokenProvider.generateToken(userId, role);
@@ -50,7 +50,7 @@ public class TokenProviderTest {
     @DisplayName("토큰에 id와 role이 포함된다")
     void token_contains_claims() {
         // given
-        String token = tokenProvider.generateToken(1L, Role.BUYER);
+        String token = tokenProvider.generateToken(1L, Role.ROLE_BUYER);
 
         // when
         Claims claims = Jwts.parser()


### PR DESCRIPTION
## 📌 개요 (What)
- JWT 인증 필터 구현

## ✨ 작업 내용
- 요청 쿠키에서 JWT 토큰 추출 로직 구현
- JWT 토큰 유효성 검증(서명, 만료시간)
- Authentication 객체 생성
- SecurityContext에 Authentication 저장
- JwtAuthenticationFilter 생성 (OncePerRequestFilter 기반)
- Security Filter Chain에 JwtAuthenticationFilter 등록

## 🔥 변경 이유

## 🧪 테스트
- [ ] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

## 🔗 관련 이슈
- close #33 
