### PR TITLE
feat: 상품 재고 수정 API 구현

### DIFF
--- a/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
@@ -3,6 +3,8 @@ package com.team10.backend.domain.product.controller;
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.dto.ProductInactiveResponse;
+import com.team10.backend.domain.product.dto.ProductStockRequest;
+import com.team10.backend.domain.product.dto.ProductStockResponse;
 import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.service.ProductService;
 import com.team10.backend.global.dto.ApiResponse;
@@ -48,5 +50,14 @@ public class ProductCommandController {
     @Operation(summary = "상품 삭제(비활성화)", description = "판매자가 등록한 상품을 삭제합니다.")
     public ApiResponse<ProductInactiveResponse> inactive(@PathVariable Long productId) {
         return ApiResponse.ok(productService.inactive(productId));
+    }
+
+    @PatchMapping("/{productId}/stock")
+    @Operation(summary = "상품 재고 수정", description = "판매자가 등록한 상품의 재고를 수정합니다.")
+    public ApiResponse<ProductStockResponse> updateStock(
+            @PathVariable Long productId,
+            @RequestBody @Valid ProductStockRequest request
+    ) {
+        return ApiResponse.ok(productService.updateStock(productId, request));
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductQueryController.java
@@ -8,13 +8,16 @@ import com.team10.backend.domain.product.service.ProductService;
 import com.team10.backend.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/products")
@@ -27,8 +30,8 @@ public class ProductQueryController {
     @Operation(summary = "상품 전체 조회",
             description = "등록된 상품 목록을 최신순으로 조회하며, 페이지 및 필터 조건을 지원합니다.")
     public ApiResponse<ProductPageResponse> list(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
+            @RequestParam(defaultValue = "10") @Min(value = 1, message = "size는 1 이상이어야 합니다.") int size,
             @RequestParam(required = false) ProductType type,
             @RequestParam(required = false) ProductStatus status
     ) {

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductCreateRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.URL;
 
 public record ProductCreateRequest(
 
@@ -20,6 +21,7 @@ public record ProductCreateRequest(
         @Min(value = 0, message = "재고는 0 이상이어야 합니다.")
         int stock,
 
+        @URL(message = "올바른 이미지 URL 형식이어야 합니다.")
         String imageUrl,
 
         @NotNull(message = "상품 종류를 선택해 주세요.")

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductStockRequest.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductStockRequest.java
@@ -1,0 +1,9 @@
+package com.team10.backend.domain.product.dto;
+
+import jakarta.validation.constraints.Min;
+
+public record ProductStockRequest(
+        @Min(value = 0, message = "재고는 0 이상이어야 합니다.")
+        int stock
+) {
+}

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductStockResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductStockResponse.java
@@ -1,0 +1,11 @@
+package com.team10.backend.domain.product.dto;
+
+public record ProductStockResponse(
+        Long productId,
+        int stock,
+        String message
+) {
+    public static ProductStockResponse of(Long productId, int stock) {
+        return new ProductStockResponse(productId, stock, "상품 재고가 수정되었습니다.");
+    }
+}

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductUpdateRequest.java
@@ -2,14 +2,30 @@ package com.team10.backend.domain.product.dto;
 
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.URL;
 
 public record ProductUpdateRequest(
+
+        @NotBlank(message = "상품명은 필수입니다.")
+        @Size(max = 30, message = "상품명은 30자 이하여야 합니다.")
         String productName,
+
         String description,
+
+        @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
         int price,
-        int stock,
+
+        @URL(message = "올바른 이미지 URL 형식이어야 합니다.")
         String imageUrl,
+
+        @NotNull(message = "상품 종류는 필수입니다.")
         ProductType type,
+
+        @NotNull(message = "상품 상태는 필수입니다.")
         ProductStatus status
 ) {
 }

--- a/src/main/java/com/team10/backend/domain/product/entity/Product.java
+++ b/src/main/java/com/team10/backend/domain/product/entity/Product.java
@@ -70,7 +70,6 @@ public class Product extends BaseEntity {
             String productName,
             String description,
             int price,
-            int stock,
             String imageUrl,
             ProductStatus status
     ) {
@@ -78,8 +77,15 @@ public class Product extends BaseEntity {
         this.productName = productName;
         this.description = description;
         this.price = price;
-        this.stock = stock;
         this.imageUrl = imageUrl;
         this.status = status;
+    }
+
+    public void updateStock(int stock) {
+        this.stock = stock;
+    }
+
+    public void inactivate() {
+        this.status = ProductStatus.INACTIVE;
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -5,6 +5,8 @@ import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.dto.ProductInactiveResponse;
 import com.team10.backend.domain.product.dto.ProductListResponse;
 import com.team10.backend.domain.product.dto.ProductPageResponse;
+import com.team10.backend.domain.product.dto.ProductStockRequest;
+import com.team10.backend.domain.product.dto.ProductStockResponse;
 import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
@@ -77,12 +79,15 @@ public class ProductService {
         );
     }
 
+    @Transactional(readOnly = true)
     public ProductDetailResponse detail(Long productId) {
 
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        if (product.getStatus() == ProductStatus.INACTIVE) throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
+        if (product.getStatus() == ProductStatus.INACTIVE) {
+            throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
 
         return ProductDetailResponse.from(product);
     }
@@ -99,7 +104,6 @@ public class ProductService {
                 request.productName(),
                 request.description(),
                 request.price(),
-                request.stock(),
                 request.imageUrl(),
                 request.status()
         );
@@ -119,5 +123,19 @@ public class ProductService {
         product.updateStatus(ProductStatus.INACTIVE);
 
         return ProductInactiveResponse.from(product);
+    }
+
+    @Transactional
+    public ProductStockResponse updateStock(Long productId, ProductStockRequest request) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        if (product.getStatus() == ProductStatus.INACTIVE) {
+            throw new BusinessException(ErrorCode.PRODUCT_ALREADY_INACTIVE);
+        }
+
+        product.updateStock(request.stock());
+
+        return ProductStockResponse.of(product.getId(), product.getStock());
     }
 }

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
@@ -1,6 +1,7 @@
 package com.team10.backend.domain.product.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team10.backend.domain.product.dto.ProductStockRequest;
 import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
@@ -119,7 +120,6 @@ class ProductCommandControllerTest {
                 "ABC 수정본",
                 "상품 수정",
                 12000,
-                80,
                 "https://www.exam.com/bookimg",
                 ProductType.BOOK,
                 ProductStatus.SELLING
@@ -134,7 +134,7 @@ class ProductCommandControllerTest {
                 .andExpect(jsonPath("$.data.productName").value("ABC 수정본"))
                 .andExpect(jsonPath("$.data.description").value("상품 수정"))
                 .andExpect(jsonPath("$.data.price").value(12000))
-                .andExpect(jsonPath("$.data.stock").value(80))
+                .andExpect(jsonPath("$.data.stock").value(10))
                 .andExpect(jsonPath("$.data.imageUrl").value("https://www.exam.com/bookimg"))
                 .andExpect(jsonPath("$.data.type").value("BOOK"))
                 .andExpect(jsonPath("$.data.status").value("SELLING"));
@@ -143,7 +143,7 @@ class ProductCommandControllerTest {
         assertThat(product.getProductName()).isEqualTo("ABC 수정본");
         assertThat(product.getDescription()).isEqualTo("상품 수정");
         assertThat(product.getPrice()).isEqualTo(12000);
-        assertThat(product.getStock()).isEqualTo(80);
+        assertThat(product.getStock()).isEqualTo(10);
         assertThat(product.getImageUrl()).isEqualTo("https://www.exam.com/bookimg");
         assertThat(product.getType()).isEqualTo(ProductType.BOOK);
         assertThat(product.getStatus()).isEqualTo(ProductStatus.SELLING);
@@ -200,5 +200,45 @@ class ProductCommandControllerTest {
                 .andExpect(status().isConflict());
     }
 
+    @Test
+    @DisplayName("재고 수정 성공")
+    void updateStock_success() throws Exception {
+        jdbcTemplate.update(
+                "INSERT INTO products " +
+                        "(id, user_id, type, product_name, description, price, stock, image_url, status, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                1L,
+                1L,
+                "BOOK",
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://www.exam.com/oldimg",
+                "SELLING"
+        );
 
+        ProductStockRequest request = new ProductStockRequest(30);
+
+        mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/stock", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.productId").value(1))
+                .andExpect(jsonPath("$.data.stock").value(30))
+                .andExpect(jsonPath("$.data.message").value("상품 재고가 수정되었습니다."));
+    }
+
+    @Test
+    @DisplayName("재고를 음수로 수정하면 검증 실패")
+    void updateStock_fail_negativeStock() throws Exception {
+        ProductStockRequest request = new ProductStockRequest(-1);
+
+        mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/stock", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_FAILED"));
+    }
 }

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductQueryControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductQueryControllerTest.java
@@ -58,7 +58,7 @@ class ProductQueryControllerTest {
     }
 
     @Test
-    @DisplayName("상품 전체 조회 시 type, status 필터 적용 성공")
+    @DisplayName("상품 전체 조회 시, type/status 필터 적용 성공")
     void listProducts_withTypeAndStatusFilter_success() throws Exception {
         mockMvc.perform(get("/api/v1/products")
                         .param("page", "0")

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -4,6 +4,8 @@ import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.dto.ProductInactiveResponse;
 import com.team10.backend.domain.product.dto.ProductPageResponse;
+import com.team10.backend.domain.product.dto.ProductStockRequest;
+import com.team10.backend.domain.product.dto.ProductStockResponse;
 import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
@@ -64,7 +66,7 @@ class ProductServiceTest {
     }
 
     @Test
-    @DisplayName("상품 생성 시 SELLING 상태")
+    @DisplayName("상품 생성 시, SELLING 상태")
     void createProduct_defaultStatusSelling() {
         ProductCreateRequest request = new ProductCreateRequest("ABC", "책 설명입니다.", 10000, 100, null, ProductType.BOOK);
 
@@ -206,7 +208,6 @@ class ProductServiceTest {
                 "수정된 상품명",
                 "수정된 설명",
                 12000,
-                20,
                 "https://example.com/new.jpg",
                 ProductType.EBOOK,
                 ProductStatus.SOLD_OUT
@@ -218,7 +219,6 @@ class ProductServiceTest {
         assertThat(response.productName()).isEqualTo("수정된 상품명");
         assertThat(response.description()).isEqualTo("수정된 설명");
         assertThat(response.price()).isEqualTo(12000);
-        assertThat(response.stock()).isEqualTo(20);
         assertThat(response.imageUrl()).isEqualTo("https://example.com/new.jpg");
         assertThat(response.type()).isEqualTo(ProductType.EBOOK);
         assertThat(response.status()).isEqualTo(ProductStatus.SOLD_OUT);
@@ -231,7 +231,6 @@ class ProductServiceTest {
                 "수정된 상품명",
                 "수정된 설명",
                 12000,
-                20,
                 "https://example.com/new.jpg",
                 ProductType.BOOK,
                 ProductStatus.SELLING
@@ -268,7 +267,7 @@ class ProductServiceTest {
     }
 
     @Test
-    @DisplayName("이미 비활성화된 상품 재요청 시 예외 발생")
+    @DisplayName("이미 비활성화된 상품 재요청 시, 예외 발생")
     void inactiveProduct_fail_alreadyInactive() {
         User user = userRepository.findById(1L).orElseThrow();
 
@@ -295,5 +294,66 @@ class ProductServiceTest {
         assertThatThrownBy(() -> productService.inactive(9999L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("재고 수정 성공")
+    void updateStock_success() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://example.com/old.jpg"
+        ));
+
+        ProductStockRequest request = new ProductStockRequest(30);
+
+        ProductStockResponse response = productService.updateStock(savedProduct.getId(), request);
+
+        assertThat(response.productId()).isEqualTo(savedProduct.getId());
+        assertThat(response.stock()).isEqualTo(30);
+        assertThat(response.message()).isEqualTo("상품 재고가 수정되었습니다.");
+
+        Product product = productRepository.findById(savedProduct.getId()).orElseThrow();
+        assertThat(product.getStock()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 재고 수정 시, 예외 발생")
+    void updateStock_fail_productNotFound() {
+        ProductStockRequest request = new ProductStockRequest(30);
+
+        assertThatThrownBy(() -> productService.updateStock(9999L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("비활성화된 상품 재고 수정 시, 예외 발생")
+    void updateStock_fail_inactiveProduct() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://example.com/old.jpg"
+        ));
+
+        savedProduct.inactivate();
+
+        ProductStockRequest request = new ProductStockRequest(30);
+
+        assertThatThrownBy(() -> productService.updateStock(savedProduct.getId(), request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.PRODUCT_ALREADY_INACTIVE.getMessage());
     }
 }


### PR DESCRIPTION
## 📌 개요 (What)
판매자가 재고만 별도로 수정할 수 있는 재고 수정 API를 구현했습니다.

## ✨ 작업 내용
- 상품 재고 수정 API 추가
- 재고 수정 전용 DTO 추가
- 상품 수정 API에서 stock 필드 제거
- 재고 수정 서비스 로직 추가
- 상품 조회 API 요청값 검증 보완
- 관련 테스트 코드 작성 및 수정
- Swagger 문서화

## 🔥 변경 이유
기존에는 상품 수정 API에서 재고를 함께 수정할 수 있게 구현되어서 상품 정보 수정과 재고 관리를 별도 API로 분리해 역할을 명확히 하고, 재고 관련 검증 및 예외 처리를 독립적으로 관리할 수 있도록 개선했습니다.

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
- 상품 수정 API에서는 stock 수정이 불가합니다.
- 재고 변경은 재고 수정 API를 통해서만 가능합니다.
- 인증/인가(401/403) 관련 세부 ErrorCode 처리는 현재 담당 범위에서 제외되어 문서상 보류 상태입니다.
- 주문 생성/취소 시 재고 차감/복원 연동은 order 도메인 작업과 연결이 필요합니다.

## 🔗 관련 이슈
- close #39 

## 📸 API 명세서
<img width="709" height="329" alt="스크린샷 2026-04-17 오후 2 55 40" src="https://github.com/user-attachments/assets/76632926-12d5-4e16-9f8f-14c41b1aee58" />
<img width="709" height="883" alt="스크린샷 2026-04-17 오후 2 55 59" src="https://github.com/user-attachments/assets/1e3c859d-b697-4418-861f-6e20b0542ef9" />
<img width="709" height="521" alt="스크린샷 2026-04-17 오후 2 56 11" src="https://github.com/user-attachments/assets/d8ab24b0-2657-4c92-8879-9b56f97b128a" />
<img width="709" height="352" alt="스크린샷 2026-04-17 오후 2 56 27" src="https://github.com/user-attachments/assets/b932f549-d342-414b-b774-9f38d27fbe42" />
<img width="709" height="436" alt="스크린샷 2026-04-17 오후 2 56 36" src="https://github.com/user-attachments/assets/2da7d7a6-2ac7-4a07-bc5f-342e6c2afaee" />
<img width="709" height="286" alt="스크린샷 2026-04-17 오후 2 56 47" src="https://github.com/user-attachments/assets/1fb477cd-bb8d-40c8-9d3b-e92ed49d0f97" />