### PR TITLE
feat: Refresh Token 쿠키 저장 및 토큰 재발급API 구현

### DIFF
--- a/src/main/java/com/team10/backend/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/team10/backend/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,50 @@
+package com.team10.backend.domain.auth.entity;
+
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    private LocalDateTime expiresAt;
+
+    private boolean isRevoked;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    public static RefreshToken create(String token, User user) {
+        return RefreshToken.builder()
+                .token(token)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .isRevoked(false)
+                .user(user)
+                .build();
+    }
+
+    public void update(String token) {
+        this.token = token;
+        this.expiresAt = LocalDateTime.now().plusDays(30);
+    }
+
+    public void revoke() {
+        this.isRevoked = true;
+    }
+}

--- a/src/main/java/com/team10/backend/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/team10/backend/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.team10.backend.domain.auth.repository;
+
+import com.team10.backend.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+}

--- a/src/main/java/com/team10/backend/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/team10/backend/domain/auth/service/RefreshTokenService.java
@@ -1,0 +1,61 @@
+package com.team10.backend.domain.auth.service;
+
+import com.team10.backend.domain.auth.entity.RefreshToken;
+import com.team10.backend.domain.auth.repository.RefreshTokenRepository;
+import com.team10.backend.domain.user.dto.RefreshResult;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
+import com.team10.backend.global.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenProvider tokenProvider;
+
+    @Transactional
+    public String createRefreshToken(User user) {
+        String token = UUID.randomUUID().toString();
+        RefreshToken refreshToken = RefreshToken.create(token, user);
+        refreshTokenRepository.save(refreshToken);
+        return token;
+    }
+
+    @Transactional
+    public RefreshResult refresh(String token) {
+        RefreshToken oldRefreshToken = validateRefreshToken(token);
+        oldRefreshToken.revoke();
+
+        User user = oldRefreshToken.getUser();
+
+        String newAccessToken = tokenProvider.generateToken(user.getId(), user.getRole());
+        String newRefreshToken = createRefreshToken(user);
+
+        return new RefreshResult(newAccessToken, newRefreshToken);
+    }
+
+    private RefreshToken validateRefreshToken(String token) {
+        if(token == null || token.isBlank()) {
+            throw new BusinessException(ErrorCode.MISSING_REFRESH_TOKEN);
+        }
+
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(token)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+        // 로그아웃 상태 || 이미 사용한 토큰 || 만료일이 지난 토큰
+        if(refreshToken.isRevoked() || refreshToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        return refreshToken;
+    }
+
+}

--- a/src/main/java/com/team10/backend/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/team10/backend/domain/auth/service/RefreshTokenService.java
@@ -58,4 +58,12 @@ public class RefreshTokenService {
         return refreshToken;
     }
 
+    @Transactional
+    public void revoke(String token) {
+        if (token == null || token.isBlank()) {
+            return;
+        }
+        refreshTokenRepository.findByToken(token).ifPresent(RefreshToken::revoke);
+    }
+
 }

--- a/src/main/java/com/team10/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/team10/backend/domain/user/controller/AuthController.java
@@ -28,6 +28,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.team10.backend.global.constant.CookieConstants.ACCESS_TOKEN;
+import static com.team10.backend.global.constant.CookieConstants.REFRESH_TOKEN;
+
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -64,8 +67,8 @@ public class AuthController {
                                 HttpServletResponse response
     ) {
         LoginResult result = authService.login(request);
-        cookieUtil.addCookie(response, "accessToken", result.accessToken());
-        cookieUtil.addCookie(response, "refreshToken", result.refreshToken());
+        cookieUtil.addCookie(response, ACCESS_TOKEN, result.accessToken());
+        cookieUtil.addCookie(response, REFRESH_TOKEN, result.refreshToken());
 
         return ApiResponse.ok(result.response());
     }
@@ -75,11 +78,11 @@ public class AuthController {
     public ApiResponse<Void> refresh(HttpServletRequest request,
                                  HttpServletResponse response
     ) {
-        String refreshToken = cookieUtil.getCookieValue(request, "refreshToken");
+        String refreshToken = cookieUtil.getCookieValue(request, REFRESH_TOKEN);
         RefreshResult result = refreshTokenService.refresh(refreshToken);
 
-        cookieUtil.addCookie(response, "accessToken", result.accessToken());
-        cookieUtil.addCookie(response, "refreshToken", result.refreshToken());
+        cookieUtil.addCookie(response, ACCESS_TOKEN, result.accessToken());
+        cookieUtil.addCookie(response, REFRESH_TOKEN, result.refreshToken());
 
         return ApiResponse.ok();
     }
@@ -89,11 +92,11 @@ public class AuthController {
     public ApiResponse<Void> logout(HttpServletRequest request,
                                     HttpServletResponse response
     ) {
-        String refreshToken = cookieUtil.getCookieValue(request, "refreshToken");
+        String refreshToken = cookieUtil.getCookieValue(request, REFRESH_TOKEN);
         refreshTokenService.revoke(refreshToken);
 
-        cookieUtil.deleteCookie(response, "accessToken");
-        cookieUtil.deleteCookie(response, "refreshToken");
+        cookieUtil.deleteCookie(response, ACCESS_TOKEN);
+        cookieUtil.deleteCookie(response, REFRESH_TOKEN);
 
         return ApiResponse.ok();
     }

--- a/src/main/java/com/team10/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/team10/backend/domain/user/controller/AuthController.java
@@ -1,17 +1,20 @@
 package com.team10.backend.domain.user.controller;
 
+import com.team10.backend.domain.auth.service.RefreshTokenService;
 import com.team10.backend.domain.user.dto.AuthRegisterRequest;
 import com.team10.backend.domain.user.dto.AuthRegisterResponse;
 import com.team10.backend.domain.user.dto.DuplicateCheckResponse;
 import com.team10.backend.domain.user.dto.LoginRequest;
 import com.team10.backend.domain.user.dto.LoginResponse;
 import com.team10.backend.domain.user.dto.LoginResult;
+import com.team10.backend.domain.user.dto.RefreshResult;
 import com.team10.backend.domain.user.enums.DuplicateType;
 import com.team10.backend.domain.user.service.AuthService;
 import com.team10.backend.global.dto.ApiResponse;
 import com.team10.backend.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -33,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final RefreshTokenService refreshTokenService;
     private final CookieUtil cookieUtil;
 
     @PostMapping("/register")
@@ -61,8 +65,23 @@ public class AuthController {
     ) {
         LoginResult result = authService.login(request);
         cookieUtil.addCookie(response, "accessToken", result.accessToken());
+        cookieUtil.addCookie(response, "refreshToken", result.refreshToken());
 
         return ApiResponse.ok(result.response());
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "토큰 재발급", description = "401에러 시 토큰을 재발급 받습니다.")
+    public ApiResponse<Void> refresh(HttpServletRequest request,
+                                 HttpServletResponse response
+    ) {
+        String token = cookieUtil.getCookieValue(request, "refreshToken");
+        RefreshResult result = refreshTokenService.refresh(token);
+
+        cookieUtil.addCookie(response, "accessToken", result.accessToken());
+        cookieUtil.addCookie(response, "refreshToken", result.refreshToken());
+
+        return ApiResponse.ok();
     }
 
 }

--- a/src/main/java/com/team10/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/team10/backend/domain/user/controller/AuthController.java
@@ -75,11 +75,25 @@ public class AuthController {
     public ApiResponse<Void> refresh(HttpServletRequest request,
                                  HttpServletResponse response
     ) {
-        String token = cookieUtil.getCookieValue(request, "refreshToken");
-        RefreshResult result = refreshTokenService.refresh(token);
+        String refreshToken = cookieUtil.getCookieValue(request, "refreshToken");
+        RefreshResult result = refreshTokenService.refresh(refreshToken);
 
         cookieUtil.addCookie(response, "accessToken", result.accessToken());
         cookieUtil.addCookie(response, "refreshToken", result.refreshToken());
+
+        return ApiResponse.ok();
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자 로그아웃을 진행합니다.")
+    public ApiResponse<Void> logout(HttpServletRequest request,
+                                    HttpServletResponse response
+    ) {
+        String refreshToken = cookieUtil.getCookieValue(request, "refreshToken");
+        refreshTokenService.revoke(refreshToken);
+
+        cookieUtil.deleteCookie(response, "accessToken");
+        cookieUtil.deleteCookie(response, "refreshToken");
 
         return ApiResponse.ok();
     }

--- a/src/main/java/com/team10/backend/domain/user/dto/RefreshResult.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/RefreshResult.java
@@ -1,7 +1,6 @@
 package com.team10.backend.domain.user.dto;
 
-public record LoginResult(
-        LoginResponse response,
+public record RefreshResult(
         String accessToken,
         String refreshToken
 ) {}

--- a/src/main/java/com/team10/backend/domain/user/service/AuthService.java
+++ b/src/main/java/com/team10/backend/domain/user/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.team10.backend.domain.user.service;
 
+import com.team10.backend.domain.auth.service.RefreshTokenService;
 import com.team10.backend.domain.user.dto.AuthRegisterRequest;
 import com.team10.backend.domain.user.dto.AuthRegisterResponse;
 import com.team10.backend.domain.user.dto.DuplicateCheckResponse;
@@ -27,6 +28,7 @@ public class AuthService {
     private final AuthRepository authRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Transactional
     public AuthRegisterResponse register(AuthRegisterRequest request) {
@@ -64,10 +66,11 @@ public class AuthService {
 
     public LoginResult login(LoginRequest request) {
         User user = authenticate(request);
-        String accessToken = generateToken(user);
+        String accessToken = tokenProvider.generateToken(user.getId(), user.getRole());
+        String refreshToken = refreshTokenService.createRefreshToken(user);
 
         LoginResponse response = LoginResponse.from(user);
-        return new LoginResult(response, accessToken);
+        return new LoginResult(response, accessToken, refreshToken);
     }
 
     private User authenticate(LoginRequest request) {
@@ -79,10 +82,6 @@ public class AuthService {
         }
 
         return user;
-    }
-
-    private String generateToken(User user) {
-        return tokenProvider.generateToken(user.getId(), user.getRole());
     }
 
 }

--- a/src/main/java/com/team10/backend/global/constant/CookieConstants.java
+++ b/src/main/java/com/team10/backend/global/constant/CookieConstants.java
@@ -1,0 +1,9 @@
+package com.team10.backend.global.constant;
+
+public final class CookieConstants {
+    private CookieConstants() {}
+
+    public static final String ACCESS_TOKEN = "accessToken";
+    public static final String REFRESH_TOKEN = "refreshToken";
+
+}

--- a/src/main/java/com/team10/backend/global/constant/JwtConstants.java
+++ b/src/main/java/com/team10/backend/global/constant/JwtConstants.java
@@ -1,0 +1,7 @@
+package com.team10.backend.global.constant;
+
+public final class JwtConstants {
+    private JwtConstants() {}
+
+    public static final String CLAIMS_ROLE = "role";
+}

--- a/src/main/java/com/team10/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/team10/backend/global/exception/ErrorCode.java
@@ -30,7 +30,12 @@ public enum ErrorCode {
     COMMENT_ACCESS_DENIED("FEED_COMMENT_002", "피드 댓글에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
     // === 주문 도메인 (5000~5999) ===
-    ORDER_NOT_FOUND("ORDER_001", "주문 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    ORDER_NOT_FOUND("ORDER_001", "주문 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    // === 인증 (6000-6999) ===
+    MISSING_REFRESH_TOKEN("AUTH_001", "refreshToken 값이 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_REFRESH_TOKEN("AUTH_002", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    ;
 
     private final String code;        // 프론트에서 분기용 비즈니스 코드
     private final String message;     // 기본 메시지 (상세 설명은 동적 생성 가능)

--- a/src/main/java/com/team10/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team10/backend/global/security/JwtAuthenticationFilter.java
@@ -16,6 +16,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+import static com.team10.backend.global.constant.CookieConstants.ACCESS_TOKEN;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -30,7 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException
     {
         // 쿠키 확인
-        String token = cookieUtil.getCookieValue(request,"accessToken");
+        String token = cookieUtil.getCookieValue(request, ACCESS_TOKEN);
 
         if(token == null || token.isBlank()) {
            filterChain.doFilter(request, response);

--- a/src/main/java/com/team10/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/team10/backend/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.team10.backend.global.exception.ErrorResponseUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -28,6 +29,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
                         .requestMatchers("/favicon.ico").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/members/login", "/api/v1/members/join").permitAll()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/members/logout").permitAll()
+//                        .requestMatchers("/api/v1/feed/me/**", "/api/v1/stores/me/products/**").hasRole("SELLER")
                         .anyRequest().permitAll()
                 )
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/team10/backend/global/security/TokenProvider.java
+++ b/src/main/java/com/team10/backend/global/security/TokenProvider.java
@@ -15,6 +15,8 @@ import javax.crypto.SecretKey;
 import java.util.Date;
 import java.util.List;
 
+import static com.team10.backend.global.constant.JwtConstants.CLAIMS_ROLE;
+
 public class TokenProvider {
 
     private final long expireTime;
@@ -32,7 +34,7 @@ public class TokenProvider {
 
         return Jwts.builder()
                 .subject(String.valueOf(id))
-                .claim("role", role)
+                .claim(CLAIMS_ROLE, role)
                 .issuedAt(issuedAt)
                 .expiration(expiresAt)
                 .signWith(key)
@@ -54,7 +56,7 @@ public class TokenProvider {
     public Authentication getAuthentication(String token) {
         Claims claims = parseClaims(token);
         String userId = claims.getSubject();
-        String role = claims.get("role", String.class);
+        String role = claims.get(CLAIMS_ROLE, String.class);
 
         UserDetails userDetails = new User(
                 userId,

--- a/src/main/java/com/team10/backend/global/security/TokenProvider.java
+++ b/src/main/java/com/team10/backend/global/security/TokenProvider.java
@@ -28,18 +28,18 @@ public class TokenProvider {
 
     public String generateToken(Long id, Role role) {
         Date issuedAt = new Date();
-        Date expireDate = calculateExpireDate(issuedAt);
+        Date expiresAt = calculateExpiresAt(issuedAt);
 
         return Jwts.builder()
                 .subject(String.valueOf(id))
                 .claim("role", role)
                 .issuedAt(issuedAt)
-                .expiration(expireDate)
+                .expiration(expiresAt)
                 .signWith(key)
                 .compact();
     }
 
-    private Date calculateExpireDate(Date issuedAt) {
+    private Date calculateExpiresAt(Date issuedAt) {
         return new Date(issuedAt.getTime() + expireTime * 1000 * 60);
     }
 

--- a/src/main/java/com/team10/backend/global/util/CookieUtil.java
+++ b/src/main/java/com/team10/backend/global/util/CookieUtil.java
@@ -33,4 +33,15 @@ public class CookieUtil {
         return null;
     }
 
+    public void deleteCookie(HttpServletResponse response, String name) {
+        Cookie cookie = new Cookie(name, "");
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setDomain("localhost");
+        cookie.setMaxAge(0);
+        cookie.setSecure(true);
+
+        response.addCookie(cookie);
+    }
+
 }

--- a/src/test/java/com/team10/backend/domain/user/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/team10/backend/domain/user/integration/AuthIntegrationTest.java
@@ -277,7 +277,8 @@ class AuthIntegrationTest {
         // then
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.email").value("user@example.com"))
-                .andExpect(cookie().exists("accessToken"));
+                .andExpect(cookie().exists("accessToken"))
+                .andExpect(cookie().exists("refreshToken"));
     }
 
     @Test
@@ -312,6 +313,8 @@ class AuthIntegrationTest {
 
         // then
         result.andExpect(status().isBadRequest());
+        result.andExpect(cookie().doesNotExist("accessToken"));
+        result.andExpect(cookie().doesNotExist("refreshToken"));
     }
 
 }

--- a/src/test/java/com/team10/backend/domain/user/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/team10/backend/domain/user/integration/AuthIntegrationTest.java
@@ -4,7 +4,7 @@ import com.team10.backend.domain.user.controller.AuthController;
 import com.team10.backend.domain.user.dto.AuthRegisterRequest;
 import com.team10.backend.domain.user.dto.LoginRequest;
 import com.team10.backend.domain.user.enums.Role;
-import com.team10.backend.domain.user.repository.AuthRepository;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,9 +33,6 @@ class AuthIntegrationTest {
 
     @Autowired
     MockMvc mvc;
-
-    @Autowired
-    private AuthRepository authRepository;
 
     @Autowired
     ObjectMapper objectMapper;
@@ -315,6 +312,55 @@ class AuthIntegrationTest {
         result.andExpect(status().isBadRequest());
         result.andExpect(cookie().doesNotExist("accessToken"));
         result.andExpect(cookie().doesNotExist("refreshToken"));
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공")
+    void logout_success() throws Exception {
+        // given
+        AuthRegisterRequest registerRequest = new AuthRegisterRequest(
+                "user@example.com",
+                "SecurePass123!",
+                "홍길동",
+                "길동이",
+                "010-1111-2222",
+                "서울",
+                Role.BUYER
+        );
+
+        mvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerRequest)));
+
+        // login
+        LoginRequest loginRequest = new LoginRequest(
+                "user@example.com",
+                "SecurePass123!"
+        );
+
+        ResultActions loginResult = mvc.perform(
+                post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest))
+        );
+
+        Cookie refreshCookie = loginResult.andReturn()
+                .getResponse()
+                .getCookie("refreshToken");
+
+        assert refreshCookie != null;
+
+        // when
+        ResultActions result = mvc.perform(
+                post("/api/v1/auth/logout")
+                        .cookie(refreshCookie)
+        ).andDo(print());
+
+        // then
+        result.andExpect(status().isOk());
+
+        result.andExpect(cookie().maxAge("accessToken", 0));
+        result.andExpect(cookie().maxAge("refreshToken", 0));
     }
 
 }

--- a/src/test/java/com/team10/backend/domain/user/unit/AuthServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/user/unit/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.team10.backend.domain.user.unit;
 
+import com.team10.backend.domain.auth.service.RefreshTokenService;
 import com.team10.backend.domain.user.dto.AuthRegisterRequest;
 import com.team10.backend.domain.user.dto.AuthRegisterResponse;
 import com.team10.backend.domain.user.dto.DuplicateCheckResponse;
@@ -45,6 +46,9 @@ class AuthServiceTest {
 
     @Mock
     private TokenProvider tokenProvider;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
 
     @InjectMocks
     private AuthService authService;
@@ -188,6 +192,7 @@ class AuthServiceTest {
         given(passwordEncoder.matches(request.password(), user.getPassword()))
                             .willReturn(true);
         given(tokenProvider.generateToken(user.getId(), user.getRole())).willReturn("test-access-token");
+        given(refreshTokenService.createRefreshToken(user)).willReturn("test-refresh-token");
 
         // when
         LoginResult result = authService.login(request);
@@ -195,6 +200,7 @@ class AuthServiceTest {
         // then
         assertEquals(user.getEmail(), result.response().email());
         assertEquals("test-access-token", result.accessToken());
+        assertEquals("test-refresh-token", result.refreshToken());
     }
 
     @Test
@@ -220,6 +226,7 @@ class AuthServiceTest {
         assertEquals(ErrorCode.LOGIN_FAILED, ex.getErrorCode());
 
         then(tokenProvider).should(never()).generateToken(any(), any());
+        then(refreshTokenService).should(never()).createRefreshToken(any());
     }
 
 

--- a/src/test/java/com/team10/backend/domain/user/unit/RefreshTokenServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/user/unit/RefreshTokenServiceTest.java
@@ -1,0 +1,177 @@
+package com.team10.backend.domain.user.unit;
+
+import com.team10.backend.domain.auth.entity.RefreshToken;
+import com.team10.backend.domain.auth.repository.RefreshTokenRepository;
+import com.team10.backend.domain.auth.service.RefreshTokenService;
+import com.team10.backend.domain.user.dto.RefreshResult;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.user.enums.Role;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
+import com.team10.backend.global.security.TokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class RefreshTokenServiceTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @Test
+    @DisplayName("refreshToken 생성 성공")
+    void createRefreshToken_success() {
+        // given
+        User user = User.builder()
+                .role(Role.BUYER)
+                .build();
+
+        RefreshToken savedToken = mock(RefreshToken.class);
+
+        given(refreshTokenRepository.save(any(RefreshToken.class)))
+                .willReturn(savedToken);
+
+        // when
+        String result = refreshTokenService.createRefreshToken(user);
+
+        // then
+        assertNotNull(result);
+        assertFalse(result.isBlank());
+
+        then(refreshTokenRepository).should(times(1)).save(any(RefreshToken.class));
+    }
+
+
+    @Test
+    @DisplayName("토큰 재발급 성공")
+    void refresh_success() {
+        // given
+        User user = User.builder()
+                .role(Role.BUYER)
+                .build();
+
+        RefreshToken refreshToken = mock(RefreshToken.class);
+
+        given(refreshToken.getUser()).willReturn(user);
+        given(refreshToken.isRevoked()).willReturn(false);
+        given(refreshToken.getExpiresAt()).willReturn(LocalDateTime.now().plusDays(1));
+
+        given(refreshTokenRepository.findByToken("old-token"))
+                .willReturn(Optional.of(refreshToken));
+
+        given(tokenProvider.generateToken(user.getId(), user.getRole()))
+                .willReturn("new-access-token");
+
+        given(refreshTokenRepository.save(any(RefreshToken.class)))
+                .willReturn(mock(RefreshToken.class));
+
+        // when
+        RefreshResult result = refreshTokenService.refresh("old-token");
+
+        // then
+        assertEquals("new-access-token", result.accessToken());
+        assertNotNull(result.refreshToken());
+
+        then(refreshToken).should().revoke();
+        then(refreshTokenRepository).should(times(1)).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("refreshToken이 null인 경우")
+    void refresh_fail_null_token() {
+        // when & then
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> refreshTokenService.refresh(null)
+        );
+
+        assertEquals(ErrorCode.MISSING_REFRESH_TOKEN, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("refreshToken이 없는 값인 경우")
+    void refresh_fail_invalid_token() {
+        // given
+        given(refreshTokenRepository.findByToken("bad-token"))
+                .willReturn(Optional.empty());
+
+        // when & then
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> refreshTokenService.refresh("bad-token")
+        );
+
+        assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("폐기된 토큰인 경우(isRevoked = true)")
+    void refresh_fail_revoked_token() {
+        // given
+        User user = User.builder()
+                .role(Role.BUYER)
+                .build();
+
+        RefreshToken refreshToken = RefreshToken.create("token", user);
+        refreshToken.revoke();
+
+        given(refreshTokenRepository.findByToken("token"))
+                .willReturn(Optional.of(refreshToken));
+
+        // when & then
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> refreshTokenService.refresh("token")
+        );
+
+        assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("만료기한이 지난 경우")
+    void refresh_fail_expired_token() {
+        // given
+        RefreshToken refreshToken = mock(RefreshToken.class);
+
+        given(refreshToken.isRevoked()).willReturn(false);
+        given(refreshToken.getExpiresAt()).willReturn(LocalDateTime.now().minusDays(1));
+
+        given(refreshTokenRepository.findByToken("token"))
+                .willReturn(Optional.of(refreshToken));
+
+        // when & then
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> refreshTokenService.refresh("token")
+        );
+
+        assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, ex.getErrorCode());
+    }
+
+}
+
+
+


### PR DESCRIPTION
## 📌 개요 (What)
- Access Token 만료 시 Refresh Token을 이용해 새로운 Access Token 및 Refresh Token을 갱신 수 있도록 구현한다.
- 사용자가 로그아웃 시 현재 사용 중인 Refresh Token을 무효화하고, 클라이언트의 인증 정보를 제거한다.

## ✨ 작업 내용
- Refresh Token 생성 로직 구현 (로그인 시 함께 발급 -> 쿠키 저장)
- Refresh Token 검증 로직 구현 (만료 확인)
- Access Token, Refresh Token 재발급 API (/auth/refresh) 구현
- Refresh Token 기반으로 새로운 Access Token, Refresh Token 발급 처리
- Refresh Token 만료 또는 위조 시 예외 처리
<br>

- 로그아웃 API 구현 (POST /logout)
- 쿠키에서 refreshToken 추출
- DB에서 해당 RefreshToken 조회 후 revoke 처리 (isRevoked = true)
- accessToken, refreshToken 쿠키 만료 처리

## 🔥 변경 이유

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
로그아웃까지 한 브랜치에서 작업했습니다

## 🔗 관련 이슈
- close #38 
- close #43 
