### PR TITLE
feat: SpringSecurity CORS 설정 추가

### DIFF
--- a/src/main/java/com/team10/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/team10/backend/global/security/SecurityConfig.java
@@ -13,7 +13,11 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -26,6 +30,7 @@ public class SecurityConfig {
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
                         .requestMatchers("/favicon.ico").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
@@ -66,4 +71,22 @@ public class SecurityConfig {
 
         return http.build();
     }
+
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration =new CorsConfiguration();
+
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+
+        configuration.setAllowedHeaders(List.of("*"));
+
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+
+        return source;
+    }
+
 }


### PR DESCRIPTION
## 📌 개요 (What)
- CORS 설정 추가 (Spring Security 포함)
- 
## ✨ 작업 내용
- CorsConfigurationSource Bean 등록
- 허용 Origin 설정 (http://localhost:3000)
- SecurityConfig에 .cors() 적용

## 🔥 변경 이유
- 브라우저에서 cross-origin 요청이 차단되어 정상 통신 불가

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [ ] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

## 🔗 관련 이슈
- close #
