### PR TITLE
feat: 상품 관리 API 인가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,30 +35,41 @@ public class ProductCommandController {
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "상품 등록", description = "판매자가 신규 상품을 등록합니다.")
     public ApiResponse<ProductDetailResponse> create(
-            @RequestBody @Valid ProductCreateRequest request) {
-        return ApiResponse.ok(productService.create(1L, request));
+            @RequestBody @Valid ProductCreateRequest request,
+            Authentication authentication) {
+        Long userId = Long.parseLong(authentication.getName());
+        return ApiResponse.ok(productService.create(userId, request));
     }
 
     @PutMapping("/{productId}")
     @Operation(summary = "상품 수정", description = "판매자가 등록한 상품 정보를 수정합니다.")
     public ApiResponse<ProductDetailResponse> update(
-            @PathVariable Long productId, @RequestBody @Valid ProductUpdateRequest request
+            @PathVariable Long productId,
+            @RequestBody @Valid ProductUpdateRequest request,
+            Authentication authentication
     ) {
-        return ApiResponse.ok(productService.update(productId, request));
+        Long userId = Long.parseLong(authentication.getName());
+        return ApiResponse.ok(productService.update(userId, productId, request));
     }
 
     @PatchMapping("/{productId}/inactive")
     @Operation(summary = "상품 삭제(비활성화)", description = "판매자가 등록한 상품을 삭제합니다.")
-    public ApiResponse<ProductInactiveResponse> inactive(@PathVariable Long productId) {
-        return ApiResponse.ok(productService.inactive(productId));
+    public ApiResponse<ProductInactiveResponse> inactive(
+            @PathVariable Long productId,
+            Authentication authentication
+    ) {
+        Long userId = Long.parseLong(authentication.getName());
+        return ApiResponse.ok(productService.inactive(userId, productId));
     }
 
     @PatchMapping("/{productId}/stock")
     @Operation(summary = "상품 재고 수정", description = "판매자가 등록한 상품의 재고를 수정합니다.")
     public ApiResponse<ProductStockResponse> updateStock(
             @PathVariable Long productId,
-            @RequestBody @Valid ProductStockRequest request
+            @RequestBody @Valid ProductStockRequest request,
+            Authentication authentication
     ) {
-        return ApiResponse.ok(productService.updateStock(productId, request));
+        Long userId = Long.parseLong(authentication.getName());
+        return ApiResponse.ok(productService.updateStock(userId, productId, request));
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -93,12 +93,10 @@ public class ProductService {
     }
 
     @Transactional
-    public ProductDetailResponse update(Long productId, ProductUpdateRequest request) {
+    public ProductDetailResponse update(Long userId, Long productId, ProductUpdateRequest request) {
 
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+        Product product = getAuthorizedProduct(userId, productId);
 
-        // TODO: 인증/인가 적용 후 판매자 권한 및 본인 상품 여부 검증 추가
         product.update(
                 request.type(),
                 request.productName(),
@@ -112,9 +110,8 @@ public class ProductService {
     }
 
     @Transactional
-    public ProductInactiveResponse inactive(Long productId) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+    public ProductInactiveResponse inactive(Long userId, Long productId) {
+        Product product = getAuthorizedProduct(userId, productId);
 
         if (product.getStatus() == ProductStatus.INACTIVE) {
             throw new BusinessException(ErrorCode.PRODUCT_ALREADY_INACTIVE);
@@ -126,9 +123,8 @@ public class ProductService {
     }
 
     @Transactional
-    public ProductStockResponse updateStock(Long productId, ProductStockRequest request) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+    public ProductStockResponse updateStock(Long userId, Long productId, ProductStockRequest request) {
+        Product product = getAuthorizedProduct(userId, productId);
 
         if (product.getStatus() == ProductStatus.INACTIVE) {
             throw new BusinessException(ErrorCode.PRODUCT_ALREADY_INACTIVE);
@@ -137,5 +133,16 @@ public class ProductService {
         product.updateStock(request.stock());
 
         return ProductStockResponse.of(product.getId(), product.getStock());
+    }
+
+    private Product getAuthorizedProduct(Long userId, Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        if (!product.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+
+        return product;
     }
 }

--- a/src/main/java/com/team10/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/team10/backend/global/security/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/members/login", "/api/v1/members/join").permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/members/logout").permitAll()
-//                        .requestMatchers("/api/v1/feed/me/**", "/api/v1/stores/me/products/**").hasRole("SELLER")
+                        .requestMatchers("/api/v1/feed/me/**", "/api/v1/stores/me/products/**").hasRole("SELLER")
                         .anyRequest().permitAll()
                 )
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
@@ -1,6 +1,6 @@
 package com.team10.backend.domain.product.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.team10.backend.domain.product.dto.ProductStockRequest;
 import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.entity.Product;
@@ -15,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -22,8 +23,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -40,6 +41,9 @@ class ProductCommandControllerTest {
 
     @Autowired
     private ProductRepository productRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
@@ -60,10 +64,78 @@ class ProductCommandControllerTest {
                 "ACTIVE",
                 "SELLER"
         );
+
+        jdbcTemplate.update(
+                "INSERT INTO users " +
+                        "(id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                2L,
+                "seller2@test.com",
+                "1234",
+                "테스트판매자2",
+                "seller2",
+                "010-9999-8888",
+                "부산시",
+                "ACTIVE",
+                "SELLER"
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO users " +
+                        "(id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                3L,
+                "buyer@test.com",
+                "1234",
+                "테스트구매자",
+                "buyer1",
+                "010-1111-2222",
+                "대구시",
+                "ACTIVE",
+                "BUYER"
+        );
     }
 
     @Test
-    @DisplayName("상품 등록")
+    @DisplayName("비로그인 사용자의 상품 등록 요청은 401")
+    void createProduct_fail_unauthorized() throws Exception {
+        String requestBody = """
+                {
+                  "productName": "ABC",
+                  "price": 10000,
+                  "stock": 100,
+                  "type": "BOOK"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/stores/me/products")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("BUYER 권한 사용자의 상품 등록 요청은 403")
+    @WithMockUser(username = "3", roles = "BUYER")
+    void createProduct_fail_forbidden() throws Exception {
+        String requestBody = """
+                {
+                  "productName": "ABC",
+                  "price": 10000,
+                  "stock": 100,
+                  "type": "BOOK"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/stores/me/products")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("상품 등록 성공")
+    @WithMockUser(username = "1", roles = "SELLER")
     void createProduct_success() throws Exception {
         String requestBody = """
                 {
@@ -99,7 +171,8 @@ class ProductCommandControllerTest {
     }
 
     @Test
-    @DisplayName("상품 수정")
+    @DisplayName("상품 수정 성공")
+    @WithMockUser(username = "1", roles = "SELLER")
     void updateProduct_success() throws Exception {
         jdbcTemplate.update(
                 "INSERT INTO products " +
@@ -127,7 +200,7 @@ class ProductCommandControllerTest {
 
         mockMvc.perform(put("/api/v1/stores/me/products/{productId}", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.productId").value(1))
@@ -150,7 +223,43 @@ class ProductCommandControllerTest {
     }
 
     @Test
-    @DisplayName("상품 비활성화")
+    @DisplayName("본인 상품이 아닌 상품 수정 요청은 403")
+    @WithMockUser(username = "2", roles = "SELLER")
+    void updateProduct_fail_accessDenied() throws Exception {
+        jdbcTemplate.update(
+                "INSERT INTO products " +
+                        "(id, user_id, type, product_name, description, price, stock, image_url, status, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                1L,
+                1L,
+                "BOOK",
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://www.exam.com/oldimg",
+                "SELLING"
+        );
+
+        ProductUpdateRequest request = new ProductUpdateRequest(
+                "ABC 수정본",
+                "상품 수정",
+                12000,
+                "https://www.exam.com/bookimg",
+                ProductType.BOOK,
+                ProductStatus.SELLING
+        );
+
+        mockMvc.perform(put("/api/v1/stores/me/products/{productId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("COMMON_003"));
+    }
+
+    @Test
+    @DisplayName("상품 비활성화 성공")
+    @WithMockUser(username = "1", roles = "SELLER")
     void inactiveProduct_success() throws Exception {
         jdbcTemplate.update(
                 "INSERT INTO products " +
@@ -180,6 +289,7 @@ class ProductCommandControllerTest {
 
     @Test
     @DisplayName("이미 비활성화된 상품 재요청 시 409")
+    @WithMockUser(username = "1", roles = "SELLER")
     void inactiveProduct_fail_alreadyInactive() throws Exception {
         jdbcTemplate.update(
                 "INSERT INTO products " +
@@ -202,6 +312,7 @@ class ProductCommandControllerTest {
 
     @Test
     @DisplayName("재고 수정 성공")
+    @WithMockUser(username = "1", roles = "SELLER")
     void updateStock_success() throws Exception {
         jdbcTemplate.update(
                 "INSERT INTO products " +
@@ -222,7 +333,7 @@ class ProductCommandControllerTest {
 
         mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/stock", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.productId").value(1))
@@ -232,12 +343,13 @@ class ProductCommandControllerTest {
 
     @Test
     @DisplayName("재고를 음수로 수정하면 검증 실패")
+    @WithMockUser(username = "1", roles = "SELLER")
     void updateStock_fail_negativeStock() throws Exception {
         ProductStockRequest request = new ProductStockRequest(-1);
 
         mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/stock", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("VALIDATION_FAILED"));
     }

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -63,12 +63,34 @@ class ProductServiceTest {
                 "ACTIVE",
                 "SELLER"
         );
+
+        jdbcTemplate.update(
+                "INSERT INTO users " +
+                        "(id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                2L,
+                "seller2@test.com",
+                "1234",
+                "테스트판매자2",
+                "seller2",
+                "010-9999-8888",
+                "부산시",
+                "ACTIVE",
+                "SELLER"
+        );
     }
 
     @Test
     @DisplayName("상품 생성 시, SELLING 상태")
     void createProduct_defaultStatusSelling() {
-        ProductCreateRequest request = new ProductCreateRequest("ABC", "책 설명입니다.", 10000, 100, null, ProductType.BOOK);
+        ProductCreateRequest request = new ProductCreateRequest(
+                "ABC",
+                "책 설명입니다.",
+                10000,
+                100,
+                null,
+                ProductType.BOOK
+        );
 
         ProductDetailResponse response = productService.create(1L, request);
 
@@ -213,7 +235,7 @@ class ProductServiceTest {
                 ProductStatus.SOLD_OUT
         );
 
-        ProductDetailResponse response = productService.update(savedProduct.getId(), request);
+        ProductDetailResponse response = productService.update(1L, savedProduct.getId(), request);
 
         assertThat(response.productId()).isEqualTo(savedProduct.getId());
         assertThat(response.productName()).isEqualTo("수정된 상품명");
@@ -236,9 +258,38 @@ class ProductServiceTest {
                 ProductStatus.SELLING
         );
 
-        assertThatThrownBy(() -> productService.update(9999L, request))
+        assertThatThrownBy(() -> productService.update(1L, 9999L, request))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("본인 상품이 아닌 상품 수정 시, 예외 발생")
+    void updateProduct_fail_accessDenied() {
+        User owner = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                owner,
+                ProductType.BOOK,
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://example.com/old.jpg"
+        ));
+
+        ProductUpdateRequest request = new ProductUpdateRequest(
+                "수정된 상품명",
+                "수정된 설명",
+                12000,
+                "https://example.com/new.jpg",
+                ProductType.EBOOK,
+                ProductStatus.SELLING
+        );
+
+        assertThatThrownBy(() -> productService.update(2L, savedProduct.getId(), request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ACCESS_DENIED.getMessage());
     }
 
     @Test
@@ -256,7 +307,7 @@ class ProductServiceTest {
                 "https://example.com/book.jpg"
         ));
 
-        ProductInactiveResponse response = productService.inactive(savedProduct.getId());
+        ProductInactiveResponse response = productService.inactive(1L, savedProduct.getId());
 
         assertThat(response.productId()).isEqualTo(savedProduct.getId());
         assertThat(response.status()).isEqualTo(ProductStatus.INACTIVE);
@@ -283,7 +334,7 @@ class ProductServiceTest {
 
         savedProduct.updateStatus(ProductStatus.INACTIVE);
 
-        assertThatThrownBy(() -> productService.inactive(savedProduct.getId()))
+        assertThatThrownBy(() -> productService.inactive(1L, savedProduct.getId()))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.PRODUCT_ALREADY_INACTIVE.getMessage());
     }
@@ -291,9 +342,29 @@ class ProductServiceTest {
     @Test
     @DisplayName("존재하지 않는 상품 비활성화 시, 예외 발생")
     void inactiveProduct_fail_productNotFound() {
-        assertThatThrownBy(() -> productService.inactive(9999L))
+        assertThatThrownBy(() -> productService.inactive(1L, 9999L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("본인 상품이 아닌 상품 비활성화 시, 예외 발생")
+    void inactiveProduct_fail_accessDenied() {
+        User owner = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                owner,
+                ProductType.BOOK,
+                "비활성화 대상 상품",
+                "상품 설명",
+                10000,
+                10,
+                "https://example.com/book.jpg"
+        ));
+
+        assertThatThrownBy(() -> productService.inactive(2L, savedProduct.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ACCESS_DENIED.getMessage());
     }
 
     @Test
@@ -313,7 +384,7 @@ class ProductServiceTest {
 
         ProductStockRequest request = new ProductStockRequest(30);
 
-        ProductStockResponse response = productService.updateStock(savedProduct.getId(), request);
+        ProductStockResponse response = productService.updateStock(1L, savedProduct.getId(), request);
 
         assertThat(response.productId()).isEqualTo(savedProduct.getId());
         assertThat(response.stock()).isEqualTo(30);
@@ -328,7 +399,7 @@ class ProductServiceTest {
     void updateStock_fail_productNotFound() {
         ProductStockRequest request = new ProductStockRequest(30);
 
-        assertThatThrownBy(() -> productService.updateStock(9999L, request))
+        assertThatThrownBy(() -> productService.updateStock(1L, 9999L, request))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
     }
@@ -352,8 +423,30 @@ class ProductServiceTest {
 
         ProductStockRequest request = new ProductStockRequest(30);
 
-        assertThatThrownBy(() -> productService.updateStock(savedProduct.getId(), request))
+        assertThatThrownBy(() -> productService.updateStock(1L, savedProduct.getId(), request))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.PRODUCT_ALREADY_INACTIVE.getMessage());
+    }
+
+    @Test
+    @DisplayName("본인 상품이 아닌 상품 재고 수정 시, 예외 발생")
+    void updateStock_fail_accessDenied() {
+        User owner = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                owner,
+                ProductType.BOOK,
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://example.com/old.jpg"
+        ));
+
+        ProductStockRequest request = new ProductStockRequest(30);
+
+        assertThatThrownBy(() -> productService.updateStock(2L, savedProduct.getId(), request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ACCESS_DENIED.getMessage());
     }
 }


### PR DESCRIPTION
## 📌 개요 (What)
상품 수정, 비활성화, 재고 수정 기능이 등록한 판매자 본인에게만 허용되도록 처리했습니다.

## ✨ 작업 내용
- SecurityConfig에 상품 관리 API 판매자 권한 검증 적용
- ProductCommandController에서 인증 사용자 ID를 받아 서비스로 전달하도록 수정
- ProductService에 본인 상품 여부 검증 로직 추가
- 상품 수정 / 비활성화 / 재고 수정 서비스 메서드 시그니처 변경
- 상품 관련 서비스 테스트 수정 및 소유자 검증 테스트 추가
- 상품 관련 컨트롤러 테스트 수정 및 인증/인가 테스트 추가
- 상품 등록 / 수정 / 비활성화 / 재고 수정 API 명세서 예외 응답 정리

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
- 403 응답이 두 경로로 나뉩니다.
    - Spring Security 권한 검사 단계: FORBIDDEN
    - 서비스 계층 소유자 검증 단계: COMMON_003
- 상품 상세/목록 조회 API에는 별도 권한 검증을 추가하지 않았습니다.

## 🔗 관련 이슈
- close #49 
