### PR TITLE
feat: 상품 전체 조회 sellerId 필터 추가

### DIFF
--- a/src/main/java/com/team10/backend/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductQueryController.java
@@ -33,9 +33,10 @@ public class ProductQueryController {
             @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
             @RequestParam(defaultValue = "10") @Min(value = 1, message = "size는 1 이상이어야 합니다.") int size,
             @RequestParam(required = false) ProductType type,
-            @RequestParam(required = false) ProductStatus status
+            @RequestParam(required = false) ProductStatus status,
+            @RequestParam(required = false) Long sellerId
     ) {
-        ProductPageResponse response = productService.list(page, size, type, status);
+        ProductPageResponse response = productService.list(page, size, type, status, sellerId);
         return ApiResponse.ok(response);
     }
 

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductListResponse.java
@@ -10,7 +10,8 @@ public record ProductListResponse(
         int price,
         String imageUrl,
         ProductType type,
-        ProductStatus status
+        ProductStatus status,
+        Long sellerId
 ) {
     public static ProductListResponse from(Product product) {
         return new ProductListResponse(
@@ -19,7 +20,8 @@ public record ProductListResponse(
                 product.getPrice(),
                 product.getImageUrl(),
                 product.getType(),
-                product.getStatus()
+                product.getStatus(),
+                product.getUser().getId()
         );
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/team10/backend/domain/product/repository/ProductRepository.java
@@ -6,8 +6,9 @@ import com.team10.backend.domain.product.enums.ProductType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpecificationExecutor<Product> {
 
     Page<Product> findByType(ProductType type, Pageable pageable);
 

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -16,14 +16,17 @@ import com.team10.backend.domain.user.entity.User;
 import com.team10.backend.domain.user.repository.UserRepository;
 import com.team10.backend.global.exception.BusinessException;
 import com.team10.backend.global.exception.ErrorCode;
+import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -54,16 +57,31 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public ProductPageResponse list(int page, int size, ProductType type, ProductStatus status) {
+    public ProductPageResponse list(int page, int size, ProductType type, ProductStatus status, Long sellerId) {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        Page<Product> productPage;
+        Specification<Product> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
 
-        if (type != null && status != null) productPage = productRepository.findByTypeAndStatus(type, status, pageable);
-        else if (type != null) productPage = productRepository.findByType(type, pageable);
-        else if (status != null) productPage = productRepository.findByStatus(status, pageable);
-        else productPage = productRepository.findByStatusNot(ProductStatus.INACTIVE, pageable);
+            if (type != null) {
+                predicates.add(cb.equal(root.get("type"), type));
+            }
+
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            } else {
+                predicates.add(cb.notEqual(root.get("status"), ProductStatus.INACTIVE));
+            }
+
+            if (sellerId != null) {
+                predicates.add(cb.equal(root.get("user").get("id"), sellerId));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+
+        Page<Product> productPage = productRepository.findAll(spec, pageable);
 
         List<ProductListResponse> content = productPage.getContent()
                 .stream()

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -3,6 +3,7 @@ package com.team10.backend.domain.product.service;
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.dto.ProductInactiveResponse;
+import com.team10.backend.domain.product.dto.ProductListResponse;
 import com.team10.backend.domain.product.dto.ProductPageResponse;
 import com.team10.backend.domain.product.dto.ProductStockRequest;
 import com.team10.backend.domain.product.dto.ProductStockResponse;
@@ -113,7 +114,7 @@ class ProductServiceTest {
         productRepository.save(new Product(user, ProductType.BOOK, "책1", "설명1", 10000, 10, null));
         productRepository.save(new Product(user, ProductType.BOOK, "책2", "설명2", 20000, 20, null));
 
-        ProductPageResponse response = productService.list(0, 10, null, null);
+        ProductPageResponse response = productService.list(0, 10, null, null, null);
 
         assertThat(response.content()).hasSize(2);
         assertThat(response.page()).isEqualTo(0);
@@ -130,7 +131,7 @@ class ProductServiceTest {
         productRepository.save(new Product(user, ProductType.BOOK, "책1", "설명1", 10000, 10, null));
         productRepository.save(new Product(user, ProductType.EBOOK, "굿즈1", "설명2", 20000, 20, null));
 
-        ProductPageResponse response = productService.list(0, 10, ProductType.BOOK, null);
+        ProductPageResponse response = productService.list(0, 10, ProductType.BOOK, null, null);
 
         assertThat(response.content()).hasSize(1);
         assertThat(response.content().get(0).productName()).isEqualTo("책1");
@@ -148,7 +149,7 @@ class ProductServiceTest {
         inactiveProduct.updateStatus(ProductStatus.INACTIVE);
         productRepository.save(inactiveProduct);
 
-        ProductPageResponse response = productService.list(0, 10, null, ProductStatus.SELLING);
+        ProductPageResponse response = productService.list(0, 10, null, ProductStatus.SELLING, null);
 
         assertThat(response.content()).hasSize(1);
         assertThat(response.content().get(0).productName()).isEqualTo("책1");
@@ -168,7 +169,7 @@ class ProductServiceTest {
 
         productRepository.save(new Product(user, ProductType.EBOOK, "전자책1", "설명3", 20000, 20, null));
 
-        ProductPageResponse response = productService.list(0, 10, ProductType.BOOK, ProductStatus.SELLING);
+        ProductPageResponse response = productService.list(0, 10, ProductType.BOOK, ProductStatus.SELLING, null);
 
         assertThat(response.content()).hasSize(1);
         assertThat(response.content().get(0).productName()).isEqualTo("책1");
@@ -448,5 +449,39 @@ class ProductServiceTest {
         assertThatThrownBy(() -> productService.updateStock(2L, savedProduct.getId(), request))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.ACCESS_DENIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("sellerId로 상품 필터링")
+    void list_withSellerId_filters() {
+        User seller = userRepository.findById(1L).orElseThrow();
+        User anotherSeller = userRepository.findById(2L).orElseThrow();
+
+        productRepository.save(new Product(
+                seller,
+                ProductType.BOOK,
+                "seller 상품",
+                "설명",
+                10000,
+                10,
+                "https://example.com/seller.jpg"
+        ));
+
+        productRepository.save(new Product(
+                anotherSeller,
+                ProductType.BOOK,
+                "다른 판매자 상품",
+                "설명",
+                12000,
+                10,
+                "https://example.com/another.jpg"
+        ));
+
+        ProductPageResponse response = productService.list(0, 10, null, null, seller.getId());
+
+        assertThat(response.content()).isNotEmpty();
+        assertThat(response.content())
+                .extracting(ProductListResponse::sellerId)
+                .containsOnly(seller.getId());
     }
 }


### PR DESCRIPTION
## 📌 개요 (What)
상품 전체 조회 API에 sellerId 필터를 추가하여 판매자 기준으로 상품 목록을 조회할 수 있도록 수정 완료했습니다.

## ✨ 작업 내용
- 상품 전체 조회 API에 sellerId를 Query Parameter 추가
- sellerId, type, status 조합 필터링 로직 반영
- 상품 목록 응답 DTO에 sellerId 필드 추가
- 관련 테스트 코드 수정 및 sellerId 필터링 테스트 추가

## 🔥 변경 이유
프론트엔드에서 판매자별 상품 목록 조회가 필요하여 기존 상품 전체 조회 API를 확장하는 방식으로 대응하기 위해 변경했습니다.

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
- sellerId는 seller_info.id가 아닌 users.id 기준
- 존재하지 않는 sellerId이거나 조회 결과가 없는 경우 예외 대신 빈 배열을 반환

## 🔗 관련 이슈
- close #57 
