### PR TITLE
refactor: CustomUserPrincipal 도입 및 인증 정보 전달 방식 개선

### DIFF
--- a/src/main/java/com/team10/backend/global/security/CustomUserPrincipal.java
+++ b/src/main/java/com/team10/backend/global/security/CustomUserPrincipal.java
@@ -1,0 +1,8 @@
+package com.team10.backend.global.security;
+
+import com.team10.backend.domain.user.enums.Role;
+
+public record CustomUserPrincipal(
+        Long userId,
+        Role role
+) {}

--- a/src/main/java/com/team10/backend/global/security/TokenProvider.java
+++ b/src/main/java/com/team10/backend/global/security/TokenProvider.java
@@ -8,8 +8,6 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
@@ -55,19 +53,13 @@ public class TokenProvider {
 
     public Authentication getAuthentication(String token) {
         Claims claims = parseClaims(token);
-        String userId = claims.getSubject();
-        String role = claims.get(CLAIMS_ROLE, String.class);
-
-        UserDetails userDetails = new User(
-                userId,
-                null,
-                List.of(new SimpleGrantedAuthority("ROLE_" + role))
-        );
+        Long userId = Long.parseLong(claims.getSubject());
+        Role role = Role.valueOf(claims.get(CLAIMS_ROLE, String.class));
 
         return new UsernamePasswordAuthenticationToken(
-                userDetails,
+                new CustomUserPrincipal(userId, role),
                 null,
-                userDetails.getAuthorities()
+                List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
         );
     }
 }

--- a/src/test/java/com/team10/backend/global/security/TokenProviderTest.java
+++ b/src/test/java/com/team10/backend/global/security/TokenProviderTest.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -93,7 +94,15 @@ public class TokenProviderTest {
 
         // then
         assertNotNull(authentication);
-        assertEquals("1", authentication.getName());
+        assertInstanceOf(CustomUserPrincipal.class, authentication.getPrincipal());
+        assertEquals(CustomUserPrincipal.class, authentication.getPrincipal().getClass());
+
+        CustomUserPrincipal principal =
+                (CustomUserPrincipal) authentication.getPrincipal();
+
+        assertEquals(1L, principal.userId());
+        assertEquals(Role.BUYER, principal.role());
+
         assertEquals(1, authentication.getAuthorities().size());
         assertTrue(
                 authentication.getAuthorities().stream()


### PR DESCRIPTION
## 📌 개요 (What)
- CustomUserPrincipal 도입 및 인증 정보 전달 방식 변경

## ✨ 작업 내용
- CustomUserPrincipal(record) 클래스 추가
- CustomUserPrincipal을 Authentication의 principal로 설정

## 🔥 변경 이유
- 사용자 식별 및 권한 정보를 객체 형태로 관리하도록 하였습니다.
- 
## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

## 🔗 관련 이슈
- close #
