### PR TITLE
feat: 사용자/판매자 프로필 조회

### DIFF
--- a/src/main/java/com/team10/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/team10/backend/domain/auth/service/AuthService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import static com.team10.backend.global.exception.ErrorCode.INVALID_INPUT;
 import static com.team10.backend.global.exception.ErrorCode.LOGIN_FAILED;
@@ -62,7 +63,7 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public DuplicateCheckResponse checkDuplicate(DuplicateType type, String value) {
-        if (value == null || value.isBlank()) {
+        if (!StringUtils.hasText(value)) {
             throw new BusinessException(INVALID_INPUT);
         }
         value = value.trim().toLowerCase();

--- a/src/main/java/com/team10/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/team10/backend/domain/auth/service/AuthService.java
@@ -6,8 +6,10 @@ import com.team10.backend.domain.auth.dto.DuplicateCheckResponse;
 import com.team10.backend.domain.auth.dto.LoginRequest;
 import com.team10.backend.domain.auth.dto.LoginResponse;
 import com.team10.backend.domain.auth.dto.LoginResult;
+import com.team10.backend.domain.user.entity.SellerInfo;
 import com.team10.backend.domain.user.entity.User;
 import com.team10.backend.domain.user.enums.DuplicateType;
+import com.team10.backend.domain.user.enums.Role;
 import com.team10.backend.domain.user.repository.UserRepository;
 import com.team10.backend.global.exception.BusinessException;
 import com.team10.backend.global.exception.ErrorCode;
@@ -35,7 +37,15 @@ public class AuthService {
 
         String encodedPassword = passwordEncoder.encode(request.password());
 
-        User user = User.create(request, encodedPassword);
+        Role role = request.role();
+
+        User user = User.create(request, encodedPassword, role);
+
+        if(role == Role.SELLER) {
+            SellerInfo sellerInfo = new SellerInfo();
+            user.attachSellerInfo(sellerInfo);
+        }
+
         User savedUser = userRepository.save(user);
 
         return AuthRegisterResponse.from(savedUser);

--- a/src/main/java/com/team10/backend/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/team10/backend/domain/auth/service/RefreshTokenService.java
@@ -1,8 +1,8 @@
 package com.team10.backend.domain.auth.service;
 
+import com.team10.backend.domain.auth.dto.RefreshResult;
 import com.team10.backend.domain.auth.entity.RefreshToken;
 import com.team10.backend.domain.auth.repository.RefreshTokenRepository;
-import com.team10.backend.domain.auth.dto.RefreshResult;
 import com.team10.backend.domain.user.entity.User;
 import com.team10.backend.global.exception.BusinessException;
 import com.team10.backend.global.exception.ErrorCode;
@@ -10,6 +10,7 @@ import com.team10.backend.global.security.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -43,7 +44,7 @@ public class RefreshTokenService {
     }
 
     private RefreshToken validateRefreshToken(String token) {
-        if(token == null || token.isBlank()) {
+        if(!StringUtils.hasText(token)) {
             throw new BusinessException(ErrorCode.MISSING_REFRESH_TOKEN);
         }
 
@@ -60,7 +61,7 @@ public class RefreshTokenService {
 
     @Transactional
     public void revoke(String token) {
-        if (token == null || token.isBlank()) {
+        if (!StringUtils.hasText(token)) {
             return;
         }
         refreshTokenRepository.findByToken(token).ifPresent(RefreshToken::revoke);

--- a/src/main/java/com/team10/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/team10/backend/domain/user/controller/UserController.java
@@ -1,0 +1,57 @@
+package com.team10.backend.domain.user.controller;
+
+import com.team10.backend.domain.user.dto.SellerResponse;
+import com.team10.backend.domain.user.dto.SellerUpdateRequest;
+import com.team10.backend.domain.user.dto.UserResponse;
+import com.team10.backend.domain.user.dto.UserUpdateRequest;
+import com.team10.backend.domain.user.service.UserService;
+import com.team10.backend.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@Tag(name =  "User/Seller Profile", description = "사용자 및 판매자 프로필 API")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/users/me")
+    public ApiResponse<UserResponse> getUserProfile() {
+        UserResponse response = userService.getUser();
+
+        return null;
+    }
+
+    @GetMapping("/sellers/me")
+    public ApiResponse<SellerResponse> getSellerProfile() {
+        return null;
+    }
+
+    @GetMapping("/sellers/{id}")
+    public ApiResponse<SellerResponse> getSellerInfo() {
+        return null;
+    }
+
+    @PutMapping("/users/me")
+    public ApiResponse<UserResponse> updateMyUserProfile(
+            @RequestBody UserUpdateRequest request
+    ) {
+        return null;
+    }
+
+    @PutMapping("sellers/me")
+    public ApiResponse<SellerResponse> updateMySellerProfile(
+            @RequestBody SellerUpdateRequest request
+    ) {
+        return null;
+    }
+
+
+}

--- a/src/main/java/com/team10/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/team10/backend/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.team10.backend.domain.user.dto.UserUpdateRequest;
 import com.team10.backend.domain.user.service.UserService;
 import com.team10.backend.global.dto.ApiResponse;
 import com.team10.backend.global.security.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,9 @@ public class UserController {
 
     @GetMapping("/users/me")
     @PreAuthorize("hasRole('BUYER')")
+    @Operation(
+            summary = "내 사용자 프로필 조회",
+            description = "로그인한 BUYER 본인의 프로필 정보를 조회합니다.")
     public ApiResponse<UserResponse> getUserProfile(
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
@@ -40,6 +44,9 @@ public class UserController {
 
     @GetMapping("/sellers/me")
     @PreAuthorize("hasRole('SELLER')")
+    @Operation(
+            summary = "내 판매자 프로필 조회",
+            description = "로그인한 SELLER 본인의 프로필 정보를 조회합니다.")
     public ApiResponse<SellerResponse> getSellerProfile(
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
@@ -49,6 +56,9 @@ public class UserController {
     }
 
     @GetMapping("/sellers/{id}")
+    @Operation(
+            summary = "판매자 공개 프로필 조회",
+            description = "특정 판매자의 공개 프로필 정보를 조회합니다.")
     public ApiResponse<SellerPublicResponse> getSellerPublicProfile(
             @PathVariable Long id
     ) {
@@ -59,6 +69,9 @@ public class UserController {
 
     @PutMapping("/users/me")
     @PreAuthorize("hasRole('BUYER')")
+    @Operation(
+            summary = "내 사용자 프로필 수정",
+            description = "로그인한 BUYER 본인의 프로필 정보를 수정합니다.")
     public ApiResponse<UserResponse> updateMyUserProfile(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @Valid @RequestBody UserUpdateRequest request
@@ -70,6 +83,9 @@ public class UserController {
 
     @PutMapping("/sellers/me")
     @PreAuthorize("hasRole('SELLER')")
+    @Operation(
+            summary = "내 판매자 프로필 수정",
+            description = "로그인한 SELLER 본인의 프로필 정보를 수정합니다.")
     public ApiResponse<SellerResponse> updateMySellerProfile(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @Valid @RequestBody SellerUpdateRequest request

--- a/src/main/java/com/team10/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/team10/backend/domain/user/controller/UserController.java
@@ -1,14 +1,19 @@
 package com.team10.backend.domain.user.controller;
 
+import com.team10.backend.domain.user.dto.SellerPublicResponse;
 import com.team10.backend.domain.user.dto.SellerResponse;
 import com.team10.backend.domain.user.dto.SellerUpdateRequest;
 import com.team10.backend.domain.user.dto.UserResponse;
 import com.team10.backend.domain.user.dto.UserUpdateRequest;
 import com.team10.backend.domain.user.service.UserService;
 import com.team10.backend.global.dto.ApiResponse;
+import com.team10.backend.global.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,34 +28,54 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/users/me")
-    public ApiResponse<UserResponse> getUserProfile() {
-        UserResponse response = userService.getUser();
+    @PreAuthorize("hasRole('BUYER')")
+    public ApiResponse<UserResponse> getUserProfile(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        UserResponse response = userService.getUserProfile(principal.userId());
 
-        return null;
+        return ApiResponse.ok(response);
     }
 
     @GetMapping("/sellers/me")
-    public ApiResponse<SellerResponse> getSellerProfile() {
-        return null;
+    @PreAuthorize("hasRole('SELLER')")
+    public ApiResponse<SellerResponse> getSellerProfile(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        SellerResponse response = userService.getSellerProfile(principal.userId());
+
+        return ApiResponse.ok(response);
     }
 
     @GetMapping("/sellers/{id}")
-    public ApiResponse<SellerResponse> getSellerInfo() {
-        return null;
+    public ApiResponse<SellerPublicResponse> getSellerPublicProfile(
+            @PathVariable Long id
+    ) {
+        SellerPublicResponse response = userService.getSellerPublicProfile(id);
+
+        return ApiResponse.ok(response);
     }
 
     @PutMapping("/users/me")
+    @PreAuthorize("hasRole('BUYER')")
     public ApiResponse<UserResponse> updateMyUserProfile(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @RequestBody UserUpdateRequest request
     ) {
-        return null;
+        UserResponse response = userService.updateMyUserProfile(principal.userId(), request);
+
+        return ApiResponse.ok(response);
     }
 
-    @PutMapping("sellers/me")
+    @PutMapping("/sellers/me")
+    @PreAuthorize("hasRole('SELLER')")
     public ApiResponse<SellerResponse> updateMySellerProfile(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @RequestBody SellerUpdateRequest request
     ) {
-        return null;
+        SellerResponse response = userService.updateMySellerProfile(principal.userId(), request);
+
+        return ApiResponse.ok(response);
     }
 
 

--- a/src/main/java/com/team10/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/team10/backend/domain/user/controller/UserController.java
@@ -9,6 +9,7 @@ import com.team10.backend.domain.user.service.UserService;
 import com.team10.backend.global.dto.ApiResponse;
 import com.team10.backend.global.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -60,7 +61,7 @@ public class UserController {
     @PreAuthorize("hasRole('BUYER')")
     public ApiResponse<UserResponse> updateMyUserProfile(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            @RequestBody UserUpdateRequest request
+            @Valid @RequestBody UserUpdateRequest request
     ) {
         UserResponse response = userService.updateMyUserProfile(principal.userId(), request);
 
@@ -71,7 +72,7 @@ public class UserController {
     @PreAuthorize("hasRole('SELLER')")
     public ApiResponse<SellerResponse> updateMySellerProfile(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            @RequestBody SellerUpdateRequest request
+            @Valid @RequestBody SellerUpdateRequest request
     ) {
         SellerResponse response = userService.updateMySellerProfile(principal.userId(), request);
 

--- a/src/main/java/com/team10/backend/domain/user/dto/SellerPublicResponse.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/SellerPublicResponse.java
@@ -1,0 +1,8 @@
+package com.team10.backend.domain.user.dto;
+
+public record SellerPublicResponse(
+        String imageUrl,
+        String name,
+        String nickname,
+        String bio
+) {}

--- a/src/main/java/com/team10/backend/domain/user/dto/SellerPublicResponse.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/SellerPublicResponse.java
@@ -1,8 +1,20 @@
 package com.team10.backend.domain.user.dto;
 
+import com.team10.backend.domain.user.entity.User;
+
 public record SellerPublicResponse(
         String imageUrl,
         String name,
         String nickname,
         String bio
-) {}
+) {
+
+    public static SellerPublicResponse from(User user) {
+        return new SellerPublicResponse(
+                user.getImageUrl(),
+                user.getName(),
+                user.getNickname(),
+                user.getSellerInfo().getBio()
+        );
+    }
+}

--- a/src/main/java/com/team10/backend/domain/user/dto/SellerResponse.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/SellerResponse.java
@@ -1,5 +1,9 @@
 package com.team10.backend.domain.user.dto;
 
+import com.team10.backend.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
 public record SellerResponse(
     Long id,
     String imageUrl,
@@ -8,6 +12,24 @@ public record SellerResponse(
     String nickname,
     String phoneNumber,
     String bio,
-    String createdAt,
-    String updatedAt
-) {}
+    String businessNumber,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+
+    public static SellerResponse from(User user) {
+        return new SellerResponse(
+                user.getId(),
+                user.getImageUrl(),
+                user.getEmail(),
+                user.getName(),
+                user.getNickname(),
+                user.getPhoneNumber(),
+                user.getSellerInfo().getBio(),
+                user.getSellerInfo().getBusinessNumber(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+
+}

--- a/src/main/java/com/team10/backend/domain/user/dto/SellerResponse.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/SellerResponse.java
@@ -1,0 +1,13 @@
+package com.team10.backend.domain.user.dto;
+
+public record SellerResponse(
+    Long id,
+    String imageUrl,
+    String email,
+    String name,
+    String nickname,
+    String phoneNumber,
+    String bio,
+    String createdAt,
+    String updatedAt
+) {}

--- a/src/main/java/com/team10/backend/domain/user/dto/SellerUpdateRequest.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/SellerUpdateRequest.java
@@ -1,9 +1,29 @@
 package com.team10.backend.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 public record SellerUpdateRequest(
-    String nickname,
-    String phoneNumber,
-    String address,
-    String bio,
-    String businessNumber
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Pattern(
+                regexp = "^[A-Za-z0-9가-힣_]{2,20}$",
+                message = "닉네임은 2~20자이며, 영문/숫자/한글/_만 사용할 수 있습니다."
+        )
+        String nickname,
+
+        @NotBlank(message = "전화번호는 필수입니다.")
+        @Pattern(
+                regexp = "^010-?\\d{4}-?\\d{4}$",
+                message = "전화번호 형식이 올바르지 않습니다. (010-1234-5678)"
+        )
+        String phoneNumber,
+
+        @NotBlank(message = "주소는 필수입니다.")
+        String address,
+
+        @Size(max = 500, message = "소개글은 500자 이하입니다.")
+        String bio,
+
+        String businessNumber
 ) {}

--- a/src/main/java/com/team10/backend/domain/user/dto/SellerUpdateRequest.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/SellerUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.team10.backend.domain.user.dto;
+
+public record SellerUpdateRequest(
+    String nickname,
+    String phoneNumber,
+    String address,
+    String bio,
+    String businessNumber
+) {}

--- a/src/main/java/com/team10/backend/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/UserResponse.java
@@ -1,5 +1,7 @@
 package com.team10.backend.domain.user.dto;
 
+import com.team10.backend.domain.user.entity.User;
+
 public record UserResponse(
     Long id,
     String imageUrl,
@@ -8,4 +10,18 @@ public record UserResponse(
     String nickname,
     String phoneNumber,
     String address
-) {}
+) {
+
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getImageUrl(),
+                user.getEmail(),
+                user.getName(),
+                user.getNickname(),
+                user.getPhoneNumber(),
+                user.getAddress()
+        );
+    }
+
+}

--- a/src/main/java/com/team10/backend/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/UserResponse.java
@@ -1,0 +1,11 @@
+package com.team10.backend.domain.user.dto;
+
+public record UserResponse(
+    Long id,
+    String imageUrl,
+    String email,
+    String name,
+    String nickname,
+    String phoneNumber,
+    String address
+) {}

--- a/src/main/java/com/team10/backend/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/UserUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.team10.backend.domain.user.dto;
+
+public record UserUpdateRequest(
+    String nickname,
+    String phoneNumber,
+    String address
+) {}

--- a/src/main/java/com/team10/backend/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/UserUpdateRequest.java
@@ -1,7 +1,23 @@
 package com.team10.backend.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record UserUpdateRequest(
-    String nickname,
-    String phoneNumber,
-    String address
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Pattern(
+                regexp = "^[A-Za-z0-9가-힣_]{2,20}$",
+                message = "닉네임은 2~20자이며, 영문/숫자/한글/_만 사용할 수 있습니다."
+        )
+        String nickname,
+
+        @NotBlank(message = "전화번호는 필수입니다.")
+        @Pattern(
+                regexp = "^010-?\\d{4}-?\\d{4}$",
+                message = "전화번호 형식이 올바르지 않습니다. (010-1234-5678)"
+        )
+        String phoneNumber,
+
+        @NotBlank(message = "주소는 필수입니다.")
+        String address
 ) {}

--- a/src/main/java/com/team10/backend/domain/user/entity/SellerInfo.java
+++ b/src/main/java/com/team10/backend/domain/user/entity/SellerInfo.java
@@ -1,7 +1,12 @@
 package com.team10.backend.domain.user.entity;
 
 import com.team10.backend.global.entity.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,9 +17,17 @@ import lombok.NoArgsConstructor;
 public class SellerInfo extends BaseEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @JoinColumn(name = "user_id", unique = true)
     private User user;
 
-    @Column(name = "business_number", nullable = false, unique = true)
+    @Column()
+    private String bio;
+
+    @Column(name = "business_number", unique = true)
     private String businessNumber;
+
+    public void linkUser(User user) {
+        this.user = user;
+    }
+
 }

--- a/src/main/java/com/team10/backend/domain/user/entity/SellerInfo.java
+++ b/src/main/java/com/team10/backend/domain/user/entity/SellerInfo.java
@@ -20,7 +20,7 @@ public class SellerInfo extends BaseEntity {
     @JoinColumn(name = "user_id", unique = true)
     private User user;
 
-    @Column()
+    @Column(length = 500)
     private String bio;
 
     @Column(name = "business_number", unique = true)
@@ -28,6 +28,11 @@ public class SellerInfo extends BaseEntity {
 
     public void linkUser(User user) {
         this.user = user;
+    }
+
+    public void updateSellerInfo(String bio, String businessNumber) {
+        this.bio = bio;
+        this.businessNumber = businessNumber;
     }
 
 }

--- a/src/main/java/com/team10/backend/domain/user/entity/User.java
+++ b/src/main/java/com/team10/backend/domain/user/entity/User.java
@@ -79,4 +79,10 @@ public class User extends BaseEntity {
         sellerInfo.linkUser(this);
     }
 
+    public void updateUserInfo(String nickname, String phoneNumber, String address) {
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+    }
+
 }

--- a/src/main/java/com/team10/backend/domain/user/entity/User.java
+++ b/src/main/java/com/team10/backend/domain/user/entity/User.java
@@ -4,10 +4,12 @@ import com.team10.backend.domain.auth.dto.AuthRegisterRequest;
 import com.team10.backend.domain.user.enums.Role;
 import com.team10.backend.domain.user.enums.UserStatus;
 import com.team10.backend.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -51,7 +53,15 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Role role;
 
-    public static User create(AuthRegisterRequest request, String hashedPassword) {
+    @OneToOne(mappedBy = "user",
+            orphanRemoval = true,
+            cascade = CascadeType.ALL)
+    private SellerInfo sellerInfo;
+
+    public static User create(AuthRegisterRequest request,
+                              String hashedPassword,
+                              Role role
+    ) {
         return User.builder()
                 .email(request.email())
                 .password(hashedPassword)
@@ -60,8 +70,13 @@ public class User extends BaseEntity {
                 .phoneNumber(request.phoneNumber())
                 .address(request.address())
                 .userStatus(UserStatus.ACTIVE)
-                .role(request.role())
+                .role(role)
                 .build();
+    }
+
+    public void attachSellerInfo(SellerInfo sellerInfo) {
+        this.sellerInfo = sellerInfo;
+        sellerInfo.linkUser(this);
     }
 
 }

--- a/src/main/java/com/team10/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/team10/backend/domain/user/service/UserService.java
@@ -1,9 +1,21 @@
 package com.team10.backend.domain.user.service;
 
+import com.team10.backend.domain.user.dto.SellerPublicResponse;
+import com.team10.backend.domain.user.dto.SellerResponse;
+import com.team10.backend.domain.user.dto.SellerUpdateRequest;
 import com.team10.backend.domain.user.dto.UserResponse;
+import com.team10.backend.domain.user.dto.UserUpdateRequest;
+import com.team10.backend.domain.user.entity.SellerInfo;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.user.enums.Role;
 import com.team10.backend.domain.user.repository.UserRepository;
+import com.team10.backend.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.team10.backend.global.exception.ErrorCode.NOT_SELLER;
+import static com.team10.backend.global.exception.ErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -11,8 +23,70 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    public UserResponse getUser() {
+    @Transactional(readOnly = true)
+    public UserResponse getUserProfile(Long userId) {
+        User user = getUserEntity(userId);
 
-        return null;
+        return UserResponse.from(user);
+    }
+
+    @Transactional(readOnly = true)
+    public SellerResponse getSellerProfile(Long userId) {
+        User user = getUserEntity(userId);
+
+        validateSellerRole(user);
+
+        return SellerResponse.from(user);
+    }
+
+    @Transactional(readOnly = true)
+    public SellerPublicResponse getSellerPublicProfile(Long id) {
+        User user = getUserEntity(id);
+
+        return SellerPublicResponse.from(user);
+    }
+
+    @Transactional
+    public UserResponse updateMyUserProfile(Long id, UserUpdateRequest request) {
+        User user = getUserEntity(id);
+        user.updateUserInfo(
+                request.nickname(),
+                request.phoneNumber(),
+                request.address()
+                );
+
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public SellerResponse updateMySellerProfile(Long id, SellerUpdateRequest request) {
+        User user = getUserEntity(id);
+
+        validateSellerRole(user);
+
+        user.updateUserInfo(
+                request.nickname(),
+                request.phoneNumber(),
+                request.address()
+        );
+
+        SellerInfo sellerInfo = user.getSellerInfo();
+        sellerInfo.updateSellerInfo(
+                request.bio(),
+                request.businessNumber()
+        );
+
+        return SellerResponse.from(user);
+    }
+
+    private User getUserEntity(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+    }
+
+    private void validateSellerRole(User user) {
+        if(user.getRole() != Role.SELLER) {
+            throw new BusinessException(NOT_SELLER);
+        }
     }
 }

--- a/src/main/java/com/team10/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/team10/backend/domain/user/service/UserService.java
@@ -1,0 +1,18 @@
+package com.team10.backend.domain.user.service;
+
+import com.team10.backend.domain.user.dto.UserResponse;
+import com.team10.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserResponse getUser() {
+
+        return null;
+    }
+}

--- a/src/main/java/com/team10/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/team10/backend/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL("USER_002", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
     DUPLICATE_NICKNAME("USER_003", "이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
     LOGIN_FAILED("USER_004", "아이디 또는 비밀번호가 일치하지 않습니다.", HttpStatus.NOT_FOUND),
+    NOT_SELLER("USER_005", "판매자가 아닙니다.", HttpStatus.FORBIDDEN),
 
     // === 상품 도메인 (3000~3999) ===,
     PRODUCT_NOT_FOUND("PRODUCT_001", "상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/team10/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team10/backend/global/security/JwtAuthenticationFilter.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -34,7 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // 쿠키 확인
         String token = cookieUtil.getCookieValue(request, ACCESS_TOKEN);
 
-        if(token == null || token.isBlank()) {
+        if(!StringUtils.hasText(token)) {
            filterChain.doFilter(request, response);
            return;
         }

--- a/src/test/java/com/team10/backend/domain/auth/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/team10/backend/domain/auth/integration/AuthIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.team10.backend.domain.user.integration;
+package com.team10.backend.domain.auth.integration;
 
 import com.team10.backend.domain.auth.controller.AuthController;
 import com.team10.backend.domain.auth.dto.AuthRegisterRequest;

--- a/src/test/java/com/team10/backend/domain/auth/unit/AuthServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/auth/unit/AuthServiceTest.java
@@ -1,4 +1,4 @@
-package com.team10.backend.domain.user.unit;
+package com.team10.backend.domain.auth.unit;
 
 import com.team10.backend.domain.auth.dto.AuthRegisterRequest;
 import com.team10.backend.domain.auth.dto.AuthRegisterResponse;

--- a/src/test/java/com/team10/backend/domain/auth/unit/RefreshTokenServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/auth/unit/RefreshTokenServiceTest.java
@@ -1,4 +1,4 @@
-package com.team10.backend.domain.user.unit;
+package com.team10.backend.domain.auth.unit;
 
 import com.team10.backend.domain.auth.entity.RefreshToken;
 import com.team10.backend.domain.auth.repository.RefreshTokenRepository;

--- a/src/test/java/com/team10/backend/domain/user/integration/UserIntegrationTest.java
+++ b/src/test/java/com/team10/backend/domain/user/integration/UserIntegrationTest.java
@@ -1,0 +1,168 @@
+package com.team10.backend.domain.user.integration;
+
+import com.team10.backend.domain.user.controller.UserController;
+import com.team10.backend.domain.user.dto.SellerUpdateRequest;
+import com.team10.backend.domain.user.dto.UserUpdateRequest;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.user.repository.UserRepository;
+import com.team10.backend.domain.user.unit.UserTestFixture;
+import com.team10.backend.global.test.AuthTestHelper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+public class UserIntegrationTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    @DisplayName("유저 프로필 조회 - 성공")
+    @WithMockUser(roles = "BUYER")
+    void getUserProfile_success() throws Exception {
+        User user = UserTestFixture.createBuyer();
+        userRepository.save(user);
+
+        AuthTestHelper.setAuth(user);
+
+        ResultActions resultActions = mvc.perform(
+                get("/api/v1/users/me"))
+                    .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(UserController.class))
+                .andExpect(handler().methodName("getUserProfile"))
+                .andExpect(status().isOk());
+
+        resultActions
+                .andExpect(jsonPath("$.data.email").value("buyer@test.com"));
+    }
+
+    @Test
+    @DisplayName("유저 프로필 수정 - 성공")
+    @WithMockUser(roles = "BUYER")
+    void updateUserProfile_success() throws Exception {
+        User user = UserTestFixture.createBuyer();
+        userRepository.save(user);
+
+        AuthTestHelper.setAuth(user);
+
+        UserUpdateRequest request = new UserUpdateRequest(
+                "새로운닉네임",
+                "010-9999-9999",
+                "부산"
+        );
+
+        ResultActions resultActions = mvc.perform(
+                        put("/api/v1/users/me")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(UserController.class))
+                .andExpect(handler().methodName("updateMyUserProfile"))
+                .andExpect(status().isOk());
+
+        resultActions
+                .andExpect(jsonPath("$.data.nickname").value("새로운닉네임"));
+    }
+
+    @Test
+    @DisplayName("판매자 API 접근 실패 - BUYER")
+    @WithMockUser(roles = "BUYER")
+    void getSellerProfile_fail() throws Exception {
+        User user = UserTestFixture.createBuyer();
+        userRepository.save(user);
+
+        AuthTestHelper.setAuth(user);
+
+        ResultActions resultActions = mvc.perform(
+                get("/api/v1/sellers/me"))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("판매자 프로필 조회 - 성공")
+    @WithMockUser(roles = "SELLER")
+    void getSellerProfile_success() throws Exception {
+        User user = UserTestFixture.createSeller();
+        userRepository.save(user);
+
+        AuthTestHelper.setAuth(user);
+
+        ResultActions resultActions = mvc.perform(
+                get("/api/v1/sellers/me"))
+                    .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(UserController.class))
+                .andExpect(handler().methodName("getSellerProfile"))
+                .andExpect(status().isOk());
+
+        resultActions
+                .andExpect(jsonPath("$.data.email").value("seller@test.com"));
+    }
+
+    @Test
+    @DisplayName("판매자 프로필 수정 - 성공")
+    @WithMockUser(roles = "SELLER")
+    void updateSellerProfile_success() throws Exception {
+        User user = UserTestFixture.createSeller();
+        userRepository.save(user);
+
+        AuthTestHelper.setAuth(user);
+
+        SellerUpdateRequest request = new SellerUpdateRequest(
+                "새로운판매자",
+                "010-9999-9999",
+                "부산",
+                "새로운 소개입니다",
+                "999-99-99999"
+        );
+
+        ResultActions resultActions = mvc.perform(
+                    put("/api/v1/sellers/me")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                ).andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(UserController.class))
+                .andExpect(handler().methodName("updateMySellerProfile"))
+                .andExpect(status().isOk());
+
+        resultActions
+                .andExpect(jsonPath("$.data.nickname").value("새로운판매자"))
+                .andExpect(jsonPath("$.data.bio").value("새로운 소개입니다"))
+                .andExpect(jsonPath("$.data.businessNumber").value("999-99-99999"));
+    }
+}

--- a/src/test/java/com/team10/backend/domain/user/integration/UserIntegrationTest.java
+++ b/src/test/java/com/team10/backend/domain/user/integration/UserIntegrationTest.java
@@ -61,7 +61,7 @@ public class UserIntegrationTest {
                 .andExpect(status().isOk());
 
         resultActions
-                .andExpect(jsonPath("$.data.email").value("buyer@test.com"));
+                .andExpect(jsonPath("$.data.name").value("김구매"));
     }
 
     @Test
@@ -129,7 +129,7 @@ public class UserIntegrationTest {
                 .andExpect(status().isOk());
 
         resultActions
-                .andExpect(jsonPath("$.data.email").value("seller@test.com"));
+                .andExpect(jsonPath("$.data.name").value("송판매"));
     }
 
     @Test

--- a/src/test/java/com/team10/backend/domain/user/unit/AuthServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/user/unit/AuthServiceTest.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -54,7 +56,7 @@ class AuthServiceTest {
     private AuthService authService;
 
     @Test
-    @DisplayName("회원가입 성공")
+    @DisplayName("회원가입 성공 - BUYER")
     void register_success() {
         // given
         AuthRegisterRequest request = new AuthRegisterRequest(
@@ -71,8 +73,8 @@ class AuthServiceTest {
         given(userRepository.existsByNickname(request.nickname())).willReturn(false);
         given(passwordEncoder.encode(request.password())).willReturn("encodedPassword");
 
-        User user = User.create(request, "encodedPassword");
-        given(this.userRepository.save(any(User.class))).willReturn(user);
+        User user = User.create(request, "encodedPassword", request.role());
+        given(userRepository.save(any(User.class))).willReturn(user);
 
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
 
@@ -80,17 +82,57 @@ class AuthServiceTest {
         AuthRegisterResponse response = authService.register(request);
 
         // then
-        then(this.userRepository).should(times(1)).existsByEmail(request.email());
-        then(this.userRepository).should(times(1)).existsByNickname(request.nickname());
+        then(userRepository).should(times(1)).existsByEmail(request.email());
+        then(userRepository).should(times(1)).existsByNickname(request.nickname());
         then(passwordEncoder).should(times(1)).encode(request.password());
-        then(this.userRepository).should(times(1)).save(userCaptor.capture());
+        then(userRepository).should(times(1)).save(userCaptor.capture());
 
         User savedUser = userCaptor.getValue();
 
         assertEquals(request.email(), savedUser.getEmail());
         assertEquals("encodedPassword", savedUser.getPassword());
+        assertEquals(Role.BUYER, savedUser.getRole());
+        assertNull(savedUser.getSellerInfo());
 
         assertEquals(request.email(), response.email());
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 - SELLER")
+    void register_success_seller() {
+        // given
+        AuthRegisterRequest request = new AuthRegisterRequest(
+                "seller@example.com",
+                "SecurePass123!",
+                "홍길동",
+                "셀러",
+                "010-1111-2222",
+                "서울특별시 강남구 테헤란로 123",
+                Role.SELLER
+        );
+
+        given(userRepository.existsByEmail(request.email())).willReturn(false);
+        given(userRepository.existsByNickname(request.nickname())).willReturn(false);
+        given(passwordEncoder.encode(request.password())).willReturn("encodedPassword");
+
+        User user = User.create(request, "encodedPassword", request.role());
+        given(userRepository.save(any(User.class))).willReturn(user);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+
+        // when
+        AuthRegisterResponse response = authService.register(request);
+
+        // then
+        then(userRepository).should(times(1)).existsByEmail(request.email());
+        then(userRepository).should(times(1)).existsByNickname(request.nickname());
+        then(passwordEncoder).should(times(1)).encode(request.password());
+        then(userRepository).should(times(1)).save(userCaptor.capture());
+
+        User savedUser = userCaptor.getValue();
+
+        assertEquals(Role.SELLER, savedUser.getRole());
+        assertNotNull(savedUser.getSellerInfo());
     }
 
     @Test

--- a/src/test/java/com/team10/backend/domain/user/unit/UserServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/user/unit/UserServiceTest.java
@@ -1,0 +1,143 @@
+package com.team10.backend.domain.user.unit;
+
+import com.team10.backend.domain.user.dto.SellerResponse;
+import com.team10.backend.domain.user.dto.SellerUpdateRequest;
+import com.team10.backend.domain.user.dto.UserResponse;
+import com.team10.backend.domain.user.dto.UserUpdateRequest;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.user.repository.UserRepository;
+import com.team10.backend.domain.user.service.UserService;
+import com.team10.backend.global.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.team10.backend.global.exception.ErrorCode.NOT_SELLER;
+import static com.team10.backend.global.exception.ErrorCode.USER_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("사용자 개인정보 조회 - 성공")
+    void getUserProfile_success() {
+        // given
+        User user = UserTestFixture.createBuyer();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when
+        UserResponse response = userService.getUserProfile(1L);
+
+        // then
+        assertNotNull(response);
+        assertEquals(user.getName(), response.name());
+    }
+
+    @Test
+    @DisplayName("판매자 개인정보 조회 - 성공")
+    void getSellerProfile_success() {
+        // given
+        User user = UserTestFixture.createSeller();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when
+        SellerResponse response = userService.getSellerProfile(1L);
+
+        // then
+        assertNotNull(response);
+        assertEquals(user.getName(), response.name());
+    }
+
+    @Test
+    @DisplayName("판매자 정보 조회 - 실패 (판매자가 아닌 경우)")
+    void getSellerProfile_fail_notSeller() {
+        // given
+        User user = UserTestFixture.createBuyer();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when & then
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> userService.getSellerProfile(1L));
+
+        assertEquals(NOT_SELLER, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("사용자 개인정보 수정 - 성공")
+    void updateMyUserProfile_success() {
+        // given
+        User user = UserTestFixture.createBuyer();
+
+        UserUpdateRequest request = new UserUpdateRequest(
+                "새로운닉네임",
+                "010-9999-9999",
+                "부산"
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when
+        UserResponse response = userService.updateMyUserProfile(1L, request);
+
+        // then
+        assertNotNull(response);
+        assertEquals("새로운닉네임", response.nickname());
+        assertEquals("010-9999-9999", response.phoneNumber());
+        assertEquals("부산", response.address());
+    }
+    @Test
+    @DisplayName("판매자 개인정보 수정 - 성공")
+    void updateMySellerProfile_success() {
+        // given
+        User user = UserTestFixture.createSeller();
+
+        SellerUpdateRequest request = new SellerUpdateRequest(
+                "새로운판매자",
+                "010-8888-8888",
+                "대구",
+                "새로운 인사말입니다.",
+                "999-999-99999"
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when
+        SellerResponse response = userService.updateMySellerProfile(1L, request);
+
+        // then
+        assertNotNull(response);
+        assertEquals("새로운판매자", response.nickname());
+        assertEquals("새로운 인사말입니다.", response.bio());
+        assertEquals("999-999-99999", response.businessNumber());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자인 경우")
+    void getUserEntity_fail_notFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> userService.getUserProfile(1L));
+
+        assertEquals(USER_NOT_FOUND, ex.getErrorCode());
+    }
+
+}

--- a/src/test/java/com/team10/backend/domain/user/unit/UserTestFixture.java
+++ b/src/test/java/com/team10/backend/domain/user/unit/UserTestFixture.java
@@ -5,10 +5,12 @@ import com.team10.backend.domain.user.entity.User;
 import com.team10.backend.domain.user.enums.Role;
 import com.team10.backend.domain.user.enums.UserStatus;
 
+import java.util.UUID;
+
 public class UserTestFixture {
     public static User createBuyer() {
         return User.builder()
-                .email("buyer@test.com")
+                .email("buyer" + UUID.randomUUID() + "@test.com")
                 .password("password123!")
                 .name("김구매")
                 .nickname("buyer")
@@ -21,7 +23,7 @@ public class UserTestFixture {
 
     public static User createSeller() {
         User user = User.builder()
-                .email("seller@test.com")
+                .email("seller" + UUID.randomUUID() + "@test.com")
                 .password("password123!")
                 .name("송판매")
                 .nickname("seller")

--- a/src/test/java/com/team10/backend/domain/user/unit/UserTestFixture.java
+++ b/src/test/java/com/team10/backend/domain/user/unit/UserTestFixture.java
@@ -1,0 +1,40 @@
+package com.team10.backend.domain.user.unit;
+
+import com.team10.backend.domain.user.entity.SellerInfo;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.user.enums.Role;
+import com.team10.backend.domain.user.enums.UserStatus;
+
+public class UserTestFixture {
+    public static User createBuyer() {
+        return User.builder()
+                .email("buyer@test.com")
+                .password("password123!")
+                .name("김구매")
+                .nickname("buyer")
+                .phoneNumber("010-0000-0000")
+                .address("서울시 동대문구")
+                .userStatus(UserStatus.ACTIVE)
+                .role(Role.BUYER)
+                .build();
+    }
+
+    public static User createSeller() {
+        User user = User.builder()
+                .email("seller@test.com")
+                .password("password123!")
+                .name("송판매")
+                .nickname("seller")
+                .phoneNumber("010-1111-1111")
+                .address("서울시 동대문구")
+                .userStatus(UserStatus.ACTIVE)
+                .role(Role.SELLER)
+                .build();
+        SellerInfo sellerInfo = new SellerInfo();
+        sellerInfo.updateSellerInfo("안녕하세요", "123-123-12345");
+        user.attachSellerInfo(sellerInfo);
+
+        return user;
+    }
+
+}

--- a/src/test/java/com/team10/backend/global/test/AuthTestHelper.java
+++ b/src/test/java/com/team10/backend/global/test/AuthTestHelper.java
@@ -1,0 +1,24 @@
+package com.team10.backend.global.test;
+
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.global.security.CustomUserPrincipal;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+public class AuthTestHelper {
+    public static void setAuth(User user) {
+        CustomUserPrincipal principal =
+                new CustomUserPrincipal(user.getId(), user.getRole());
+
+        var auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}


### PR DESCRIPTION
## 📌 개요 (What)
- 사용자/판매자 프로필 조회 API 구현

## ✨ 작업 내용
- 사용자 본인 프로필 조회 API 구현 (`/users/me`)
- 사용자 본인 프로필 수정 API 구현 (`/users/me`)
- 판매자 본인 프로필 조회 API 구현 (`/sellers/me`)
- 판매자 본인 프로필 수정 API 구현 (`/sellers/me`)
- 판매자 공개 프로필 조회 API 구현 (`/sellers/{id}`)
- 판매자 권한 검증 로직 추가 (`Role.SELLER`)

## 🔥 변경 이유
- 사용자와 판매자의 프로필 정보를 각각 안전하게 조회/수정할 수 있도록 기능 분리
- 판매자 정보는 본인용 / 공개용으로 나눠 접근 제어 및 응답 구조 명확화

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

## 🔗 관련 이슈
- close #
