### PR TITLE
refactor: 피드 서비스 및 컨트롤러 수정

### DIFF
--- a/src/main/java/com/team10/backend/domain/feed/controller/FeedCommentController.java
+++ b/src/main/java/com/team10/backend/domain/feed/controller/FeedCommentController.java
@@ -7,6 +7,7 @@ import com.team10.backend.domain.feed.dto.comment.CreateCommentRequestDto;
 import com.team10.backend.domain.feed.dto.comment.UpdateCommentRequestDto;
 import com.team10.backend.domain.feed.service.FeedCommentService;
 import com.team10.backend.global.dto.ApiResponse;
+import com.team10.backend.global.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -40,9 +42,9 @@ public class FeedCommentController {
             @PathVariable Long sellerId,
             @PathVariable Long feedId,
             @RequestBody @Valid CreateCommentRequestDto requestDto,
-            Authentication authentication
+            @AuthenticationPrincipal CustomUserPrincipal currentUser
     ) {
-        return ApiResponse.ok(feedCommentService.createComment(sellerId, feedId, requestDto, currentUserId(authentication)));
+        return ApiResponse.ok(feedCommentService.createComment(sellerId, feedId, requestDto, currentUser.userId()));
     }
 
     @GetMapping
@@ -53,9 +55,11 @@ public class FeedCommentController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(defaultValue = "createdAt,desc") String sort,
-            Authentication authentication
+            @AuthenticationPrincipal CustomUserPrincipal currentUser
     ) {
-        return ApiResponse.ok(feedCommentService.getComments(sellerId, feedId, page, size, sort, nullableCurrentUserId(authentication)));
+        Long currentUserId = currentUser != null ? currentUser.userId() : null;
+
+        return ApiResponse.ok(feedCommentService.getComments(sellerId, feedId, page, size, sort, currentUserId));
     }
 
     @PatchMapping("/{commentId}")
@@ -65,9 +69,9 @@ public class FeedCommentController {
             @PathVariable Long feedId,
             @PathVariable Long commentId,
             @RequestBody @Valid UpdateCommentRequestDto requestDto,
-            Authentication authentication
-    ){
-        return ApiResponse.ok(feedCommentService.updateComment(sellerId, feedId, commentId, requestDto, currentUserId(authentication)));
+            @AuthenticationPrincipal CustomUserPrincipal currentUser
+            ){
+        return ApiResponse.ok(feedCommentService.updateComment(sellerId, feedId, commentId, requestDto, currentUser.userId()));
     }
 
     @DeleteMapping("/{commentId}")
@@ -76,9 +80,9 @@ public class FeedCommentController {
             @PathVariable Long sellerId,
             @PathVariable Long feedId,
             @PathVariable Long commentId,
-            Authentication authentication
+            @AuthenticationPrincipal CustomUserPrincipal currentUser
     ) {
-        feedCommentService.deleteComment(sellerId, feedId, commentId, currentUserId(authentication));
+        feedCommentService.deleteComment(sellerId, feedId, commentId, currentUser.userId());
         return ApiResponse.ok();
     }
 
@@ -90,9 +94,9 @@ public class FeedCommentController {
             @PathVariable Long sellerId,
             @PathVariable Long feedId,
             @PathVariable Long commentId,
-            Authentication authentication
+            @AuthenticationPrincipal CustomUserPrincipal currentUser
     ) {
-        return ApiResponse.ok(feedCommentService.toggleCommentLike(sellerId, feedId, commentId, currentUserId(authentication)));
+        return ApiResponse.ok(feedCommentService.toggleCommentLike(sellerId, feedId, commentId, currentUser.userId()));
     }
 
     private Long currentUserId(Authentication authentication) {

--- a/src/main/java/com/team10/backend/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/team10/backend/domain/feed/controller/FeedController.java
@@ -8,13 +8,13 @@ import com.team10.backend.domain.feed.dto.post.UpdateFeedRequestDto;
 import com.team10.backend.domain.feed.dto.post.UpdateFeedResponseDto;
 import com.team10.backend.domain.feed.service.FeedPostService;
 import com.team10.backend.global.dto.ApiResponse;
+import com.team10.backend.global.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -37,9 +37,11 @@ public class FeedController {
     @Operation(summary = "피드 조회", description = "피드 전체 조회 합니다.")
     public ApiResponse<FeedListResponseDto> getStoreFeeds(
             @PathVariable Long sellerId,
-            Authentication authentication
+            @AuthenticationPrincipal CustomUserPrincipal currentUser
     ) {
-        FeedListResponseDto response = feedPostService.getFeedsList(sellerId, nullableCurrentUserId(authentication));
+        Long currentUserId = currentUser != null ? currentUser.userId() : null;
+
+        FeedListResponseDto response = feedPostService.getFeedsList(sellerId, currentUserId);
         return ApiResponse.ok(response);
     }
 
@@ -48,9 +50,9 @@ public class FeedController {
     @Operation(summary = "피드 생성", description = "판매자가 피드를 생성 합니다.")
     public ApiResponse<CreateFeedResponseDto> createFeed(
             @RequestBody @Valid CreateFeedRequestDto requestDto,
-            Authentication authentication
-    ) {
-        CreateFeedResponseDto responseDto = feedPostService.createFeed(requestDto, currentUserId(authentication));
+            @AuthenticationPrincipal CustomUserPrincipal seller
+            ) {
+        CreateFeedResponseDto responseDto = feedPostService.createFeed(requestDto, seller.userId());
         return ApiResponse.ok(responseDto);
     }
 
@@ -59,10 +61,10 @@ public class FeedController {
     public ApiResponse<UpdateFeedResponseDto> updateFeed(
             @PathVariable Long feedId,
             @RequestBody @Valid UpdateFeedRequestDto requestDto,
-            Authentication authentication
+            @AuthenticationPrincipal CustomUserPrincipal seller
     ) {
         UpdateFeedResponseDto responseDto =
-                feedPostService.updateFeed(feedId, requestDto, currentUserId(authentication));
+                feedPostService.updateFeed(feedId, requestDto, seller.userId());
 
         return ApiResponse.ok(responseDto);
     }
@@ -71,9 +73,9 @@ public class FeedController {
     @Operation(summary = "피드 삭제", description = "판매자가 피드를 삭제합니다.")
     public ApiResponse<Void> deleteFeed(
             @PathVariable Long feedId,
-            Authentication authentication
+            @AuthenticationPrincipal CustomUserPrincipal seller
     ) {
-        feedPostService.deleteFeed(feedId, currentUserId(authentication));
+        feedPostService.deleteFeed(feedId, seller.userId());
 
         return ApiResponse.ok();
     }
@@ -83,23 +85,12 @@ public class FeedController {
     @Operation(summary = "피드 좋아요", description = "사용자가 피드에 좋아요를 누릅니다.")
     public ApiResponse<FeedLikeToggleResponseDto> toggleFeedLike(
             @PathVariable Long feedId,
-            Authentication authentication
+            @AuthenticationPrincipal CustomUserPrincipal currentUser
     ) {
         FeedLikeToggleResponseDto responseDto =
-                feedPostService.toggleFeedLike(feedId, currentUserId(authentication));
+                feedPostService.toggleFeedLike(feedId, currentUser.userId());
 
         return ApiResponse.ok(responseDto);
-    }
-
-    private Long currentUserId(Authentication authentication) {
-        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
-            return null;
-        }
-        return Long.valueOf(authentication.getName());
-    }
-
-    private Long nullableCurrentUserId(Authentication authentication) {
-        return currentUserId(authentication);
     }
 
 }

--- a/src/main/java/com/team10/backend/domain/feed/dto/comment/CommentLikeToggleResponseDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/comment/CommentLikeToggleResponseDto.java
@@ -1,7 +1,7 @@
 package com.team10.backend.domain.feed.dto.comment;
 
 public record CommentLikeToggleResponseDto(
-        boolean isLiked,
+        boolean liked,
         int likeCount
 ) {
 }

--- a/src/main/java/com/team10/backend/domain/feed/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/comment/CommentResponseDto.java
@@ -4,7 +4,7 @@ import com.team10.backend.domain.feed.entity.FeedComment;
 import com.team10.backend.domain.user.entity.User;
 
 public record CommentResponseDto(
-        String commentId,
+        Long commentId,
         Writer writer,
         String content,
         int likeCount,
@@ -17,7 +17,7 @@ public record CommentResponseDto(
         boolean isMine = currentUser != null && comment.getWriter().getId().equals(currentUser.getId());
 
         return new CommentResponseDto(
-                String.valueOf(comment.getId()),
+                comment.getId(),
                 Writer.from(comment.getWriter()),
                 comment.getContent(),
                 comment.getLikeCount(),
@@ -29,13 +29,13 @@ public record CommentResponseDto(
     }
 
     public record Writer(
-            String userId,
+            Long userId,
             String nickname,
             String profileImageUrl
     ) {
         public static Writer from(User writer) {
             return new Writer(
-                    String.valueOf(writer.getId()),
+                    writer.getId(),
                     writer.getNickname(),
                     writer.getImageUrl()
             );

--- a/src/main/java/com/team10/backend/domain/feed/dto/post/FeedLikeToggleResponseDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/post/FeedLikeToggleResponseDto.java
@@ -1,7 +1,7 @@
 package com.team10.backend.domain.feed.dto.post;
 
 public record FeedLikeToggleResponseDto(
-        boolean isLiked,
+        boolean liked,
         int likeCount
 ) {
 

--- a/src/main/java/com/team10/backend/domain/feed/entity/FeedLike.java
+++ b/src/main/java/com/team10/backend/domain/feed/entity/FeedLike.java
@@ -10,7 +10,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "feed_likes")
+@Table(name = "feed_likes", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_feed_like_post_user", columnNames = {"feed_post_id", "user_id"})
+})
 public class FeedLike extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/team10/backend/domain/feed/service/FeedCommentService.java
+++ b/src/main/java/com/team10/backend/domain/feed/service/FeedCommentService.java
@@ -24,6 +24,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -67,45 +69,13 @@ public class FeedCommentService {
         Page<FeedComment> commentPage = feedCommentRepository.findAllByFeedPostId(feedId, pageable);
 
         var comments = commentPage.getContent().stream()
-                .map(comment -> {
-                    boolean isLiked = currentUser != null
-                            && feedCommentLikeRepository.existsByFeedComment_IdAndUser_Id(
-                                    comment.getId(),
-                                    currentUser.getId()
-                            );
-                    return CommentResponseDto.from(comment, isLiked, currentUser);
-                })
+                .map(comment -> toCommentResponse(comment, currentUser))
                 .toList();
 
-        return new CommentListResponseDto(
-                comments,
-                new PaginationResponseDto(
-                        commentPage.getNumber(),
-                        commentPage.getTotalPages(),
-                        commentPage.getTotalElements()
-                )
-        );
+        return new CommentListResponseDto(comments, toPaginationDto(commentPage));
     }
 
-    private Pageable createPageable(int page, int size, String sort) {
-        int safePage = Math.max(page, 0);
-        int safeSize = Math.min(Math.max(size, 1), 50);
-        Sort safeSort = parseSort(sort);
 
-        return PageRequest.of(safePage, safeSize, safeSort);
-    }
-
-    private Sort parseSort(String sort) {
-        String[] sortParts = sort == null ? new String[0] : sort.split(",");
-        String property = sortParts.length > 0 && "createdAt".equals(sortParts[0])
-                ? sortParts[0]
-                : "createdAt";
-        Sort.Direction direction = sortParts.length > 1 && "asc".equalsIgnoreCase(sortParts[1])
-                ? Sort.Direction.ASC
-                : Sort.Direction.DESC;
-
-        return Sort.by(direction, property);
-    }
 
     @Transactional
     public CommentResponseDto updateComment(
@@ -129,12 +99,12 @@ public class FeedCommentService {
         feedComment.updateContent(requestDto.content());
 
 
-        boolean isLiked = feedCommentLikeRepository.existsByFeedComment_IdAndUser_Id(
+        boolean liked = feedCommentLikeRepository.existsByFeedComment_IdAndUser_Id(
                 commentId,
                 currentUser.getId()
         );
 
-        return CommentResponseDto.from(feedComment, isLiked, currentUser);
+        return CommentResponseDto.from(feedComment, liked, currentUser);
 
     }
 
@@ -147,10 +117,7 @@ public class FeedCommentService {
         FeedComment feedComment = feedCommentRepository.findByIdAndFeedPostId(commentId, feedId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
 
-        boolean isCommentWriter = feedComment.getWriter().getId().equals(currentUser.getId());
-        boolean isFeedOwner = feedPost.getUser().getId().equals(currentUser.getId());
-
-        if (!isCommentWriter && !isFeedOwner) {
+        if (!canDeleteComment(feedComment, feedPost, currentUser)) {
             throw new BusinessException(ErrorCode.COMMENT_ACCESS_DENIED);
         }
 
@@ -168,22 +135,41 @@ public class FeedCommentService {
         User currentUser = getUser(currentUserId);
 
         getFeedPost(sellerId, feedId);
+
         FeedComment feedComment = feedCommentRepository.findByIdAndFeedPostId(commentId, feedId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
 
-        boolean isLiked = feedCommentLikeRepository.findByFeedComment_IdAndUser_Id(commentId, currentUser.getId())
-                .map(commentLike -> {
-                    feedCommentLikeRepository.delete(commentLike);
-                    feedComment.decreaseLikeCount();
-                    return false;
-                })
-                .orElseGet(() -> {
-                    feedCommentLikeRepository.save(new FeedCommentLike(feedComment, currentUser));
-                    feedComment.increaseLikeCount();
-                    return true;
-                });
+        boolean liked = toggleLike(feedComment, currentUser);
 
-        return new CommentLikeToggleResponseDto(isLiked, feedComment.getLikeCount());
+        return new CommentLikeToggleResponseDto(liked, feedComment.getLikeCount());
+    }
+
+    private Pageable createPageable(int page, int size, String sort) {
+        int safePage = Math.max(page, 0);
+        int safeSize = Math.min(Math.max(size, 1), 50);
+        Sort safeSort = parseSort(sort);
+
+        return PageRequest.of(safePage, safeSize, safeSort);
+    }
+
+    private Sort parseSort(String sort) {
+        String[] sortParts = sort == null ? new String[0] : sort.split(",");
+        String property = sortParts.length > 0 && "createdAt".equals(sortParts[0])
+                ? sortParts[0]
+                : "createdAt";
+        Sort.Direction direction = sortParts.length > 1 && "asc".equalsIgnoreCase(sortParts[1])
+                ? Sort.Direction.ASC
+                : Sort.Direction.DESC;
+
+        return Sort.by(direction, property);
+    }
+
+    private PaginationResponseDto toPaginationDto(Page<FeedComment> commentPage) {
+        return new PaginationResponseDto(
+                commentPage.getNumber(),
+                commentPage.getTotalPages(),
+                commentPage.getTotalElements()
+        );
     }
 
     private FeedPost getFeedPost(Long sellerId, Long feedId) {
@@ -208,5 +194,36 @@ public class FeedCommentService {
 
     private User getNullableUser(Long userId) {
         return userId == null ? null : getUser(userId);
+    }
+
+    private CommentResponseDto toCommentResponse(FeedComment comment, User currentUser) {
+        boolean liked = currentUser != null
+                && feedCommentLikeRepository.existsByFeedComment_IdAndUser_Id(
+                comment.getId(),
+                currentUser.getId()
+        );
+        return CommentResponseDto.from(comment, liked, currentUser);
+    }
+
+    private boolean canDeleteComment(FeedComment feedComment, FeedPost feedPost, User currentUser) {
+        boolean isCommentWriter = feedComment.getWriter().getId().equals(currentUser.getId());
+        boolean isFeedOwner = feedPost.getUser().getId().equals(currentUser.getId());
+        return isCommentWriter || isFeedOwner;
+    }
+
+    private boolean toggleLike(FeedComment feedComment, User currentUser) {
+        Optional<FeedCommentLike> existingLike =
+                feedCommentLikeRepository.findByFeedComment_IdAndUser_Id(
+                        feedComment.getId(), currentUser.getId());
+
+        if (existingLike.isPresent()) {
+            feedCommentLikeRepository.delete(existingLike.get());
+            feedComment.decreaseLikeCount();
+            return false;
+        }
+
+        feedCommentLikeRepository.save(new FeedCommentLike(feedComment, currentUser));
+        feedComment.increaseLikeCount();
+        return true;
     }
 }

--- a/src/main/java/com/team10/backend/domain/feed/service/FeedPostService.java
+++ b/src/main/java/com/team10/backend/domain/feed/service/FeedPostService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +37,8 @@ public class FeedPostService {
 
     // 비로그인 조회도 허용하되, 로그인 유저라면 좋아요 여부를 함께 계산한다.
     public FeedListResponseDto getFeedsList(Long sellerId, Long currentUserId) {
-        List<FeedPost> feedPosts = feedPostRepository.findAllByUserIdOrderByCreatedAtDesc(sellerId);
+        List<FeedPost> feedPosts =
+                feedPostRepository.findAllByUserIdOrderByCreatedAtDesc(sellerId);
 
         if (feedPosts.isEmpty()) {
             throw new BusinessException(ErrorCode.FEED_NOT_FOUND);
@@ -45,14 +47,7 @@ public class FeedPostService {
         User currentUser = getNullableUser(currentUserId);
 
         List<FeedDto> feedDtos = feedPosts.stream()
-                .map(feed -> {
-                    boolean isLiked = false;
-                    if (currentUser != null) {
-                        isLiked = feed.getFeedLikes().stream()
-                                .anyMatch(like -> like.getUser().getId().equals(currentUser.getId()));
-                    }
-                    return FeedDto.from(feed, isLiked);
-                })
+                .map(feed -> toFeedDto(feed, currentUser))
                 .toList();
 
         return new FeedListResponseDto(feedDtos);
@@ -65,9 +60,7 @@ public class FeedPostService {
         validateSeller(currentUser);
 
         FeedPost feedPost = new FeedPost(
-                requestDto.mediaUrls() != null && !requestDto.mediaUrls().isEmpty()
-                    ? requestDto.mediaUrls().getFirst()
-                    : "",
+                extractThumbnailUrl(requestDto),
                 requestDto.content(),
                 currentUser
         );
@@ -87,9 +80,7 @@ public class FeedPostService {
 
         String oldImageUrl = feedPost.getImageUrl();
 
-        String newImageUrl = requestDto.mediaUrls() != null && !requestDto.mediaUrls().isEmpty()
-                ? requestDto.mediaUrls().getFirst()
-                : "";
+        String newImageUrl = extractThumbnailUrl(requestDto);
 
         if (!Objects.equals(oldImageUrl, newImageUrl)) {
             imageUploadService.deleteIfManaged(oldImageUrl);
@@ -101,25 +92,13 @@ public class FeedPostService {
     }
 
     @Transactional
-    // 좋아요는 로그인 유저라면 누구나 토글할 수 있다.
     public FeedLikeToggleResponseDto toggleFeedLike(Long feedId, Long currentUserId) {
         User currentUser = getUser(currentUserId);
-
         FeedPost feedPost = getFeedPost(feedId);
 
-        boolean isLiked = feedLikeRepository.findByFeedPostId_AndUser_Id(feedId, currentUser.getId())
-                .map(feedLike -> {
-                    feedLikeRepository.delete(feedLike);
-                    feedPost.decreaseLikeCount();
-                    return false;
-                })
-                .orElseGet(() -> {
-                    feedLikeRepository.save(new FeedLike(feedPost, currentUser));
-                    feedPost.increaseLikeCount();
-                    return true;
-                });
+        boolean liked = toggleLike(feedPost, currentUser);
 
-        return new FeedLikeToggleResponseDto(isLiked, feedPost.getLikeCount());
+        return new FeedLikeToggleResponseDto(liked, feedPost.getLikeCount());
     }
 
     @Transactional
@@ -176,5 +155,54 @@ public class FeedPostService {
         if (user.getRole() != Role.SELLER) {
             throw new BusinessException(ErrorCode.ACCESS_DENIED);
         }
+    }
+
+    // 멀티 이미지 요청이 와도 대표 이미지로 첫 번째 URL만 사용한다.
+    private String extractThumbnailUrl(CreateFeedRequestDto requestDto) {
+        return requestDto.mediaUrls() != null && !requestDto.mediaUrls().isEmpty()
+                ? requestDto.mediaUrls().getFirst()
+                : "";
+    }
+
+    // 현재 로그인 사용자의 좋아요 여부를 포함해 FeedDto로 변환한다.
+    private FeedDto toFeedDto(FeedPost feed, User currentUser) {
+        boolean liked = isLiked(feed, currentUser);
+        return FeedDto.from(feed, liked);
+    }
+
+    // 비로그인 사용자는 false, 로그인 사용자는 좋아요 여부를 계산한다.
+    private boolean isLiked(FeedPost feed, User currentUser) {
+        if (currentUser == null) {
+            return false;
+        }
+
+        return feed.getFeedLikes().stream()
+                .anyMatch(like -> like.getUser().getId().equals(currentUser.getId()));
+    }
+
+    // 수정 요청에서도 대표 이미지로 첫 번째 URL만 사용한다.
+    private String extractThumbnailUrl(UpdateFeedRequestDto requestDto) {
+        return requestDto.mediaUrls() != null && !requestDto.mediaUrls().isEmpty()
+                ? requestDto.mediaUrls().getFirst()
+                : "";
+    }
+
+    // 좋아요가 이미 있으면 취소하고, 없으면 새로 생성한다.
+    private boolean toggleLike(FeedPost feedPost, User currentUser) {
+        Optional<FeedLike> existingLike =
+                feedLikeRepository.findByFeedPostId_AndUser_Id(
+                        feedPost.getId(),
+                        currentUser.getId()
+                );
+
+        if (existingLike.isPresent()) {
+            feedLikeRepository.delete(existingLike.get());
+            feedPost.decreaseLikeCount();
+            return false;
+        }
+
+        feedLikeRepository.save(new FeedLike(feedPost, currentUser));
+        feedPost.increaseLikeCount();
+        return true;
     }
 }

--- a/src/test/java/com/team10/backend/domain/feed/controller/FeedCommentControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/feed/controller/FeedCommentControllerTest.java
@@ -1,5 +1,7 @@
 package com.team10.backend.domain.feed.controller;
 
+import com.team10.backend.domain.user.enums.Role;
+import com.team10.backend.global.security.CustomUserPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,9 +11,15 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -92,13 +100,13 @@ public class FeedCommentControllerTest {
                 """;
 
         mockMvc.perform(post("/api/v1/stores/1/feeds/100/comments")
-                        .principal(new UsernamePasswordAuthenticationToken("2", null))
+                        .with(authenticatedUser(2L, Role.BUYER))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.content").value("댓글 생성 테스트입니다."))
-                .andExpect(jsonPath("$.data.writer.userId").value("2"))
+                .andExpect(jsonPath("$.data.writer.userId").value(2))
                 .andExpect(jsonPath("$.data.isMine").value(true));
     }
 
@@ -116,7 +124,7 @@ public class FeedCommentControllerTest {
         );
 
         mockMvc.perform(get("/api/v1/stores/1/feeds/100/comments")
-                        .principal(new UsernamePasswordAuthenticationToken("2", null))
+                        .with(authenticatedUser(2L, Role.BUYER))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -185,14 +193,14 @@ public class FeedCommentControllerTest {
                 """;
 
         mockMvc.perform(patch("/api/v1/stores/1/feeds/100/comments/203")
-                        .principal(new UsernamePasswordAuthenticationToken("2", null))
+                        .with(authenticatedUser(2L, Role.BUYER))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.commentId").value("203"))
+                .andExpect(jsonPath("$.data.commentId").value(203))
                 .andExpect(jsonPath("$.data.content").value("댓글 수정 후입니다."))
-                .andExpect(jsonPath("$.data.writer.userId").value("2"))
+                .andExpect(jsonPath("$.data.writer.userId").value(2))
                 .andExpect(jsonPath("$.data.isMine").value(true));
     }
 
@@ -216,7 +224,7 @@ public class FeedCommentControllerTest {
         );
 
         mockMvc.perform(delete("/api/v1/stores/1/feeds/100/comments/201")
-                        .principal(new UsernamePasswordAuthenticationToken("2", null))
+                        .with(authenticatedUser(2L, Role.BUYER))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));
@@ -236,11 +244,24 @@ public class FeedCommentControllerTest {
         );
 
         mockMvc.perform(post("/api/v1/stores/1/feeds/100/comments/202/like")
-                        .principal(new UsernamePasswordAuthenticationToken("2", null))
+                        .with(authenticatedUser(2L, Role.BUYER))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.isLiked").value(true))
+                .andExpect(jsonPath("$.data.liked").value(true))
                 .andExpect(jsonPath("$.data.likeCount").value(1));
+    }
+
+    private RequestPostProcessor authenticatedUser(Long userId, Role role) {
+        return request -> {
+            SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+            securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(
+                    new CustomUserPrincipal(userId, role),
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
+            ));
+            SecurityContextHolder.setContext(securityContext);
+            return request;
+        };
     }
 }

--- a/src/test/java/com/team10/backend/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/feed/controller/FeedControllerTest.java
@@ -1,6 +1,8 @@
 package com.team10.backend.domain.feed.controller;
 
 import com.team10.backend.domain.feed.repository.FeedPostRepository;
+import com.team10.backend.domain.user.enums.Role;
+import com.team10.backend.global.security.CustomUserPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,9 +12,15 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -84,7 +92,7 @@ public class FeedControllerTest {
             """;
 
         mockMvc.perform(post("/api/v1/stores/me/feeds")
-                        .principal(new UsernamePasswordAuthenticationToken("1", null))
+                        .with(authenticatedUser(1L, Role.SELLER))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isCreated()) // 201 확인
@@ -115,6 +123,7 @@ public class FeedControllerTest {
         );
 
         mockMvc.perform(get("/api/v1/stores/1/feeds")
+                        .with(authenticatedUser(2L, Role.BUYER))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -144,7 +153,7 @@ public class FeedControllerTest {
             """;
 
         mockMvc.perform(patch("/api/v1/stores/me/feeds/100")
-                        .principal(new UsernamePasswordAuthenticationToken("1", null))
+                        .with(authenticatedUser(1L, Role.SELLER))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isOk())
@@ -169,7 +178,7 @@ public class FeedControllerTest {
         );
 
         mockMvc.perform(delete("/api/v1/stores/me/feeds/101")
-                        .principal(new UsernamePasswordAuthenticationToken("1", null))
+                        .with(authenticatedUser(1L, Role.SELLER))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));
@@ -192,11 +201,24 @@ public class FeedControllerTest {
         );
 
         mockMvc.perform(post("/api/v1/stores/me/feeds/100/like")
-                        .principal(new UsernamePasswordAuthenticationToken("2", null))
+                        .with(authenticatedUser(2L, Role.BUYER))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.isLiked").value(true))
+                .andExpect(jsonPath("$.data.liked").value(true))
                 .andExpect(jsonPath("$.data.likeCount").value(1));
+    }
+
+    private RequestPostProcessor authenticatedUser(Long userId, Role role) {
+        return request -> {
+            SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+            securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(
+                    new CustomUserPrincipal(userId, role),
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
+            ));
+            SecurityContextHolder.setContext(securityContext);
+            return request;
+        };
     }
 }

--- a/src/test/java/com/team10/backend/domain/feed/service/FeedCommentServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/feed/service/FeedCommentServiceTest.java
@@ -120,9 +120,9 @@ public class FeedCommentServiceTest {
                 100L
         );
 
-        assertThat(result.commentId()).isNotBlank();
+        assertThat(result.commentId()).isNotNull();
         assertThat(result.content()).isEqualTo("댓글 내용입니다.");
-        assertThat(result.writer().userId()).isEqualTo("2");
+        assertThat(result.writer().userId()).isEqualTo(2L);
         assertThat(result.isMine()).isTrue();
         assertThat(feedCommentRepository.count()).isEqualTo(1);
         assertThat(commentCount).isEqualTo(1);
@@ -194,9 +194,9 @@ public class FeedCommentServiceTest {
                 205L
         );
 
-        assertThat(result.commentId()).isEqualTo("205");
+        assertThat(result.commentId()).isEqualTo(205L);
         assertThat(result.content()).isEqualTo("수정 후 댓글입니다.");
-        assertThat(result.writer().userId()).isEqualTo("2");
+        assertThat(result.writer().userId()).isEqualTo(2L);
         assertThat(result.isLiked()).isTrue();
         assertThat(result.isMine()).isTrue();
         assertThat(updatedContent).isEqualTo("수정 후 댓글입니다.");
@@ -336,7 +336,7 @@ public class FeedCommentServiceTest {
                 2L
         );
 
-        assertThat(result.isLiked()).isTrue();
+        assertThat(result.liked()).isTrue();
         assertThat(result.likeCount()).isEqualTo(1);
         assertThat(likeCount).isEqualTo(1);
         assertThat(commentLikeCount).isEqualTo(1);
@@ -378,7 +378,7 @@ public class FeedCommentServiceTest {
                 2L
         );
 
-        assertThat(result.isLiked()).isFalse();
+        assertThat(result.liked()).isFalse();
         assertThat(result.likeCount()).isEqualTo(0);
         assertThat(likeCount).isEqualTo(0);
         assertThat(commentLikeCount).isEqualTo(0);

--- a/src/test/java/com/team10/backend/domain/feed/service/FeedPostServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/feed/service/FeedPostServiceTest.java
@@ -267,7 +267,7 @@ public class FeedPostServiceTest {
                 2L
         );
 
-        assertThat(result.isLiked()).isTrue();
+        assertThat(result.liked()).isTrue();
         assertThat(result.likeCount()).isEqualTo(1);
         assertThat(likeCount).isEqualTo(1);
         assertThat(feedLikeCount).isEqualTo(1);
@@ -310,7 +310,7 @@ public class FeedPostServiceTest {
                 2L
         );
 
-        assertThat(result.isLiked()).isFalse();
+        assertThat(result.liked()).isFalse();
         assertThat(result.likeCount()).isEqualTo(0);
         assertThat(likeCount).isEqualTo(0);
         assertThat(feedLikeCount).isEqualTo(0);


### PR DESCRIPTION
## 📌 개요 (What)
- 피드 도메인 서비스와 컨트롤러 구조 정리 및 가독성 개선

## ✨ 작업 내용
- 피드/댓글 서비스 메서드의 흐름 정리 및 보조 메서드 분리
- Optional 체인 기반 좋아요 토글 로직을 if/else 구조로 개선
- 피드/댓글 수정·삭제 시 인가(권한 검증) 로직 정리
- 피드 좋아요 엔티티에 중복 방지를 위한 제약조건(유니크) 반영
- 테스트 코드 수정

## 🔥 변경 이유
- 가독성과 유지보수성을 높이기 위해
- 부수효과가 있는 로직을 더 명확하게 표현하기 위해
- 작성자/판매자 권한 검증을 일관되게 적용하기 위해

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

## 🔗 관련 이슈
