### PR TITLE
feat: 상품 재고 수정 비관적 락 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-h2console'
     runtimeOnly'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client-test'

--- a/src/main/java/com/team10/backend/domain/product/entity/Product.java
+++ b/src/main/java/com/team10/backend/domain/product/entity/Product.java
@@ -90,22 +90,56 @@ public class Product extends BaseEntity {
 
     public void updateStock(int stock) {
         validateStock(stock);
+        applyStock(stock);
+    }
 
-        this.stock = stock;
-        updateStatusByStock();
+    public void decreaseStock(int quantity) {
+        validateQuantity(quantity);
+        validateActive();
+
+        if (this.stock < quantity) {
+            throw new BusinessException(ErrorCode.INSUFFICIENT_STOCK);
+        }
+
+        applyStock(this.stock - quantity);
+    }
+
+    public void increaseStock(int quantity) {
+        validateQuantity(quantity);
+        validateActive();
+
+        applyStock(this.stock + quantity);
     }
 
     public void inactivate() {
         this.status = ProductStatus.INACTIVE;
     }
 
+    private void applyStock(int stock) {
+        this.stock = stock;
+        updateStatusByStock();
+    }
+
+    private void validateActive() {
+        if (this.status == ProductStatus.INACTIVE) {
+            throw new BusinessException(ErrorCode.PRODUCT_ALREADY_INACTIVE);
+        }
+    }
+
     private void updateStatusByStock() {
         if (this.status == ProductStatus.INACTIVE) return;
-
         this.status = (this.stock == 0) ? ProductStatus.SOLD_OUT : ProductStatus.SELLING;
     }
 
     private void validateStock(int stock) {
-        if (stock < 0) throw new BusinessException(ErrorCode.INVALID_STOCK);
+        if (stock < 0) {
+            throw new BusinessException(ErrorCode.INVALID_STOCK);
+        }
+    }
+
+    private void validateQuantity(int quantity) {
+        if (quantity <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_STOCK_QUANTITY);
+        }
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/entity/Product.java
+++ b/src/main/java/com/team10/backend/domain/product/entity/Product.java
@@ -4,6 +4,8 @@ import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
 import com.team10.backend.domain.user.entity.User;
 import com.team10.backend.global.entity.BaseEntity;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -50,7 +52,16 @@ public class Product extends BaseEntity {
     private ProductStatus status;
 
 
-    public Product(User user, ProductType type, String productName, String description, int price, int stock, String imageUrl) {
+    public Product(
+            User user,
+            ProductType type,
+            String productName,
+            String description,
+            int price,
+            int stock,
+            String imageUrl
+    ) {
+        validateStock(stock);
         this.user = user;
         this.type = type;
         this.productName = productName;
@@ -58,11 +69,7 @@ public class Product extends BaseEntity {
         this.price = price;
         this.stock = stock;
         this.imageUrl = imageUrl;
-        this.status = ProductStatus.SELLING;
-    }
-
-    public void updateStatus(ProductStatus status) {
-        this.status = status;
+        this.status = (stock == 0) ? ProductStatus.SOLD_OUT : ProductStatus.SELLING;
     }
 
     public void update(
@@ -82,10 +89,23 @@ public class Product extends BaseEntity {
     }
 
     public void updateStock(int stock) {
+        validateStock(stock);
+
         this.stock = stock;
+        updateStatusByStock();
     }
 
     public void inactivate() {
         this.status = ProductStatus.INACTIVE;
+    }
+
+    private void updateStatusByStock() {
+        if (this.status == ProductStatus.INACTIVE) return;
+
+        this.status = (this.stock == 0) ? ProductStatus.SOLD_OUT : ProductStatus.SELLING;
+    }
+
+    private void validateStock(int stock) {
+        if (stock < 0) throw new BusinessException(ErrorCode.INVALID_STOCK);
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/team10/backend/domain/product/repository/ProductRepository.java
@@ -3,10 +3,16 @@ package com.team10.backend.domain.product.repository;
 import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpecificationExecutor<Product> {
 
@@ -17,4 +23,8 @@ public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpec
     Page<Product> findByStatusNot(ProductStatus status, Pageable pageable);
 
     Page<Product> findByTypeAndStatus(ProductType type, ProductStatus status, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Product p where p.id = :productId")
+    Optional<Product> findByIdWithPessimisticLock(@Param("productId") Long productId);
 }

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -135,14 +135,19 @@ public class ProductService {
             throw new BusinessException(ErrorCode.PRODUCT_ALREADY_INACTIVE);
         }
 
-        product.updateStatus(ProductStatus.INACTIVE);
+        product.inactivate();
 
         return ProductInactiveResponse.from(product);
     }
 
     @Transactional
     public ProductStockResponse updateStock(Long userId, Long productId, ProductStockRequest request) {
-        Product product = getAuthorizedProduct(userId, productId);
+        Product product = productRepository.findByIdWithPessimisticLock(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        if (!product.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
 
         if (product.getStatus() == ProductStatus.INACTIVE) {
             throw new BusinessException(ErrorCode.PRODUCT_ALREADY_INACTIVE);

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -129,6 +129,7 @@ public class ProductService {
 
     @Transactional
     public ProductInactiveResponse inactive(Long userId, Long productId) {
+
         Product product = getAuthorizedProduct(userId, productId);
 
         if (product.getStatus() == ProductStatus.INACTIVE) {
@@ -142,12 +143,8 @@ public class ProductService {
 
     @Transactional
     public ProductStockResponse updateStock(Long userId, Long productId, ProductStockRequest request) {
-        Product product = productRepository.findByIdWithPessimisticLock(productId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        if (!product.getUser().getId().equals(userId)) {
-            throw new BusinessException(ErrorCode.ACCESS_DENIED);
-        }
+        Product product = getAuthorizedProductWithLock(userId, productId);
 
         if (product.getStatus() == ProductStatus.INACTIVE) {
             throw new BusinessException(ErrorCode.PRODUCT_ALREADY_INACTIVE);
@@ -159,7 +156,20 @@ public class ProductService {
     }
 
     private Product getAuthorizedProduct(Long userId, Long productId) {
+
         Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        if (!product.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+
+        return product;
+    }
+
+    private Product getAuthorizedProductWithLock(Long userId, Long productId) {
+
+        Product product = productRepository.findByIdWithPessimisticLock(productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
         if (!product.getUser().getId().equals(userId)) {

--- a/src/main/java/com/team10/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/team10/backend/global/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     PRODUCT_NOT_FOUND("PRODUCT_001", "상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INSUFFICIENT_STOCK("PRODUCT_002", "재고가 부족합니다.", HttpStatus.BAD_REQUEST),
     PRODUCT_ALREADY_INACTIVE("PRODUCT_003", "이미 비활성화된 상품입니다.", HttpStatus.CONFLICT),
+    INVALID_STOCK("PRODUCT_004", "재고는 0 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_STOCK_QUANTITY("PRODUCT_005", "증감 수량은 0 이하일 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     // === 피드 도메인 (4000~4999) ===
     FEED_NOT_FOUND("FEED_001", "피드를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/resources/application-mysql.yaml
+++ b/src/main/resources/application-mysql.yaml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/team10?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true

--- a/src/test/java/com/team10/backend/domain/product/entity/ProductTest.java
+++ b/src/test/java/com/team10/backend/domain/product/entity/ProductTest.java
@@ -1,0 +1,139 @@
+package com.team10.backend.domain.product.entity;
+
+import com.team10.backend.domain.product.enums.ProductStatus;
+import com.team10.backend.domain.product.enums.ProductType;
+import com.team10.backend.domain.user.entity.User;
+import com.team10.backend.domain.user.enums.Role;
+import com.team10.backend.domain.user.enums.UserStatus;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProductTest {
+
+    private User createSeller() {
+        return User.builder()
+                .email("seller@test.com")
+                .password("1234")
+                .name("테스트판매자")
+                .nickname("seller1")
+                .phoneNumber("010-1234-5678")
+                .address("서울시")
+                .userStatus(UserStatus.ACTIVE)
+                .role(Role.SELLER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("재고 차감 성공")
+    void decreaseStock_success() {
+        Product product = new Product(
+                createSeller(),
+                ProductType.BOOK,
+                "상품명",
+                "설명",
+                10000,
+                10,
+                null
+        );
+
+        product.decreaseStock(3);
+
+        assertThat(product.getStock()).isEqualTo(7);
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.SELLING);
+    }
+
+    @Test
+    @DisplayName("재고를 모두 차감하면 상태가 SOLD_OUT으로 변경")
+    void decreaseStock_success_soldOutWhenZero() {
+        Product product = new Product(
+                createSeller(),
+                ProductType.BOOK,
+                "상품명",
+                "설명",
+                10000,
+                3,
+                null
+        );
+
+        product.decreaseStock(3);
+
+        assertThat(product.getStock()).isEqualTo(0);
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.SOLD_OUT);
+    }
+
+    @Test
+    @DisplayName("재고보다 많이 차감하면 예외 발생")
+    void decreaseStock_fail_insufficientStock() {
+        Product product = new Product(
+                createSeller(),
+                ProductType.BOOK,
+                "상품명",
+                "설명",
+                10000,
+                3,
+                null
+        );
+
+        assertThatThrownBy(() -> product.decreaseStock(5))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INSUFFICIENT_STOCK.getMessage());
+    }
+
+    @Test
+    @DisplayName("재고 증가 성공")
+    void increaseStock_success() {
+        Product product = new Product(
+                createSeller(),
+                ProductType.BOOK,
+                "상품명",
+                "설명",
+                10000,
+                0,
+                null
+        );
+
+        product.increaseStock(5);
+
+        assertThat(product.getStock()).isEqualTo(5);
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.SELLING);
+    }
+
+    @Test
+    @DisplayName("0 이하 수량 증가 요청 시 예외가 발생한다")
+    void increaseStock_fail_invalidQuantity() {
+        Product product = new Product(
+                createSeller(),
+                ProductType.BOOK,
+                "상품명",
+                "설명",
+                10000,
+                10,
+                null
+        );
+
+        assertThatThrownBy(() -> product.increaseStock(0))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("0 이하 수량 차감 요청 시 예외가 발생한다")
+    void decreaseStock_fail_invalidQuantity() {
+        Product product = new Product(
+                createSeller(),
+                ProductType.BOOK,
+                "상품명",
+                "설명",
+                10000,
+                10,
+                null
+        );
+
+        assertThatThrownBy(() -> product.decreaseStock(0))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -514,6 +514,33 @@ class ProductServiceTest {
     }
 
     @Test
+    @DisplayName("SOLD_OUT 상품의 재고가 0에서 1 이상으로 오르면 SELLING으로 변경")
+    void updateStock_success_sellingWhenStockBecomesPositive() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product soldOutProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "품절 상품",
+                "설명",
+                10000,
+                0,
+                "https://example.com/book.jpg"
+        ));
+
+        ProductStockRequest request = new ProductStockRequest(5);
+
+        ProductStockResponse response = productService.updateStock(1L, soldOutProduct.getId(), request);
+
+        assertThat(response.productId()).isEqualTo(soldOutProduct.getId());
+        assertThat(response.stock()).isEqualTo(5);
+
+        Product product = productRepository.findById(soldOutProduct.getId()).orElseThrow();
+        assertThat(product.getStock()).isEqualTo(5);
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.SELLING);
+    }
+
+    @Test
     @DisplayName("음수 재고 입력 시, 예외 발생")
     void updateStock_fail_invalidStock() {
         User user = userRepository.findById(1L).orElseThrow();

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -146,7 +146,7 @@ class ProductServiceTest {
         productRepository.save(new Product(user, ProductType.BOOK, "책1", "설명1", 10000, 10, null));
 
         Product inactiveProduct = new Product(user, ProductType.EBOOK, "전자책1", "설명2", 20000, 20, null);
-        inactiveProduct.updateStatus(ProductStatus.INACTIVE);
+        inactiveProduct.inactivate();
         productRepository.save(inactiveProduct);
 
         ProductPageResponse response = productService.list(0, 10, null, ProductStatus.SELLING, null);
@@ -164,7 +164,7 @@ class ProductServiceTest {
         productRepository.save(new Product(user, ProductType.BOOK, "책1", "설명1", 10000, 10, null));
 
         Product inactiveBook = new Product(user, ProductType.BOOK, "책2", "설명2", 15000, 5, null);
-        inactiveBook.updateStatus(ProductStatus.INACTIVE);
+        inactiveBook.inactivate();
         productRepository.save(inactiveBook);
 
         productRepository.save(new Product(user, ProductType.EBOOK, "전자책1", "설명3", 20000, 20, null));
@@ -333,7 +333,7 @@ class ProductServiceTest {
                 "https://example.com/book.jpg"
         ));
 
-        savedProduct.updateStatus(ProductStatus.INACTIVE);
+        savedProduct.inactivate();
 
         assertThatThrownBy(() -> productService.inactive(1L, savedProduct.getId()))
                 .isInstanceOf(BusinessException.class)
@@ -393,6 +393,7 @@ class ProductServiceTest {
 
         Product product = productRepository.findById(savedProduct.getId()).orElseThrow();
         assertThat(product.getStock()).isEqualTo(30);
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.SELLING);
     }
 
     @Test
@@ -483,5 +484,54 @@ class ProductServiceTest {
         assertThat(response.content())
                 .extracting(ProductListResponse::sellerId)
                 .containsOnly(seller.getId());
+    }
+
+    @Test
+    @DisplayName("재고를 0으로 수정하면 상태가 SOLD_OUT으로 변경된다")
+    void updateStock_success_soldOutWhenZero() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://example.com/old.jpg"
+        ));
+
+        ProductStockRequest request = new ProductStockRequest(0);
+
+        ProductStockResponse response = productService.updateStock(1L, savedProduct.getId(), request);
+
+        assertThat(response.productId()).isEqualTo(savedProduct.getId());
+        assertThat(response.stock()).isEqualTo(0);
+
+        Product product = productRepository.findById(savedProduct.getId()).orElseThrow();
+        assertThat(product.getStock()).isEqualTo(0);
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.SOLD_OUT);
+    }
+
+    @Test
+    @DisplayName("음수 재고 입력 시, 예외 발생")
+    void updateStock_fail_invalidStock() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://example.com/old.jpg"
+        ));
+
+        ProductStockRequest request = new ProductStockRequest(-1);
+
+        assertThatThrownBy(() -> productService.updateStock(1L, savedProduct.getId(), request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_STOCK.getMessage());
     }
 }


### PR DESCRIPTION
## 📌 개요 (What)
상품 재고의 정합성을 위해 비관적 락 적용했습니다.

## ✨ 작업 내용
- ProductRepository에 비관적 락 조회 메서드 추가
- ProductService.updateStock()에 비관적 락 기반 재고 수정 로직 적용
- 상품 재고 수정 관련 서비스 테스트 수정 및 추가
- Product 엔티티 재고 증감 로직 테스트 추가
- MySQL 환경에서 재고 수정 동시 요청 시나리오 검증

## 🔥 변경 이유

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
- 현재 비관적 락 적용 범위는 상품 재고 수정입니다.
- 주문 생성/취소와 연결되는 재고 차감/복구 동시성 제어는 Order 도메인 구현 이후 후속 작업이 필요합니다.
- application-mysql.yml은 MySQL 검증용입니다.

## 🔗 관련 이슈
- close #61 

## 📸 테스트
- 테스트 방법: 5초 딜레이를 주고 총 5개 재고에 첫 번째로 5개 차감하고 두 번째로 1개 차감 시킨 경우
- 비관적 락 X
  - 첫 번째 요청에서 5개 차감 후 0, 두 번째 요청에서도 5개에서 1개 차감하여 남은 재고 4가 됨
<img width="1322" height="766" alt="1_재고수정_동시요청1(락X)" src="https://github.com/user-attachments/assets/cc7c18a7-4003-40da-bad3-b18bfcb4a656" />
<img width="410" height="327" alt="1_재고수정_동시요청2(락X)" src="https://github.com/user-attachments/assets/1b7e7f31-88cc-4ebf-b9cc-62d9351ba044" />
<br><br>
- 비관적 락 O
  - 첫 번째 요청이 처리되고 남은 재고가 0이 되며, 두 번째 요청에서 재고 부족 발생
<img width="1322" height="766" alt="2_재고수정_동시요청1(락O)" src="https://github.com/user-attachments/assets/efe509a7-41bd-49ae-b6be-7377790a2a0e" />
<img width="419" height="326" alt="2_재고수정_동시요청2(락O)" src="https://github.com/user-attachments/assets/eb92eeb3-7121-406c-96e5-bff2d4e3b46f" />
<br><br>
- <localhost> Script-8에서 FOR UPDATE로 상품 row lock을 선점하면 <localhost> Script-9에서 동일 row 접근은 트랜잭션이 대기 상태
<img width="821" height="798" alt="2_재고수정_동시요청3(락O)" src="https://github.com/user-attachments/assets/7d079f7b-388e-441d-8c95-26090f3ec689" />
