### PR TITLE
Feat/toss payments confirm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.retry:spring-retry:2.0.5'
+    implementation 'org.springframework.boot:spring-boot-starter-aop:3.5.13'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team10/backend/Team10Application.java
+++ b/src/main/java/com/team10/backend/Team10Application.java
@@ -3,7 +3,10 @@ package com.team10.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
+
+@EnableRetry
 @SpringBootApplication
 @EnableJpaAuditing
 public class Team10Application {

--- a/src/main/java/com/team10/backend/domain/order/controller/OrderController.java
+++ b/src/main/java/com/team10/backend/domain/order/controller/OrderController.java
@@ -2,16 +2,20 @@ package com.team10.backend.domain.order.controller;
 
 import com.team10.backend.domain.order.dto.OrderCreateRequest;
 import com.team10.backend.domain.order.dto.OrderDeleteResponse;
+import com.team10.backend.domain.order.dto.confirm.ConfirmRequest;
+import com.team10.backend.domain.order.dto.confirm.TossConfirmResponse;
 import com.team10.backend.domain.order.dto.search.OrderDetailResponse;
 import com.team10.backend.domain.order.dto.search.buyer.OrderListResponse;
 import com.team10.backend.domain.order.dto.OrderResponse;
 import com.team10.backend.domain.order.dto.search.seller.SellerOrderListResponse;
 import com.team10.backend.domain.order.service.OrderService;
+import com.team10.backend.domain.order.service.PaymentService;
 import com.team10.backend.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,11 +28,14 @@ import java.security.Principal;
 public class OrderController {
 
     private final OrderService orderService;
+    private final PaymentService paymentService;
 
-    //Todo 주문 검증
-    //  주문 상태 업데이트 (PENDING -> SUCCESS)
-    //  결제 상태 업데이트 (READY -> PAID)(엔티티 내 구현)
-    //  배송 상태 업데이트 (null -> READY)(")
+    @PostMapping("/confirm")
+    @Operation(summary = "주문 검증", description = "상품을 구매할때 토스 페이먼트 api를 호출하여 검증합니다.")
+    public ApiResponse<TossConfirmResponse> confirmPayment(@RequestBody ConfirmRequest request) {
+        TossConfirmResponse response = paymentService.confirmPayment(request);
+        return ApiResponse.ok(response);
+    }
 
     @PostMapping
     @Operation(summary = "주문 등록", description = "구매자가 상품을 구매할때 주문을 생성합니다.")

--- a/src/main/java/com/team10/backend/domain/order/controller/PaymentWebhookController.java
+++ b/src/main/java/com/team10/backend/domain/order/controller/PaymentWebhookController.java
@@ -1,0 +1,28 @@
+package com.team10.backend.domain.order.controller;
+
+import com.team10.backend.domain.order.dto.webhook.WebhookPayload;
+import com.team10.backend.domain.order.service.PaymentWebhookService;
+import com.team10.backend.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/payments/webhook")
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentWebhookController {
+
+    private final PaymentWebhookService webhookService;
+
+    @PostMapping
+    public ApiResponse<Void> handleWebhook(
+            @RequestBody WebhookPayload payload
+    ) {
+        log.info("웹훅 수신: eventType={}, orderId={}", payload.eventType(), payload.data().orderId());
+
+        webhookService.processWebhook(payload);
+
+        return ApiResponse.ok(); // 200 OK를 응답해야 토스가 재전송을 안 함
+    }
+}

--- a/src/main/java/com/team10/backend/domain/order/dto/confirm/ConfirmRequest.java
+++ b/src/main/java/com/team10/backend/domain/order/dto/confirm/ConfirmRequest.java
@@ -4,6 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record ConfirmRequest(
         String paymentKey,
-         String orderNumber,
-        Long totalAmout
+        String orderId,
+        Long amount
 ) {}

--- a/src/main/java/com/team10/backend/domain/order/dto/confirm/ConfirmRequest.java
+++ b/src/main/java/com/team10/backend/domain/order/dto/confirm/ConfirmRequest.java
@@ -1,0 +1,9 @@
+package com.team10.backend.domain.order.dto.confirm;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ConfirmRequest(
+        String paymentKey,
+         String orderNumber,
+        Long totalAmout
+) {}

--- a/src/main/java/com/team10/backend/domain/order/dto/confirm/TossConfirmResponse.java
+++ b/src/main/java/com/team10/backend/domain/order/dto/confirm/TossConfirmResponse.java
@@ -1,0 +1,8 @@
+package com.team10.backend.domain.order.dto.confirm;
+
+public record TossConfirmResponse(
+        String paymentKey,
+         String orderId,
+        String orderStatus
+) {
+}

--- a/src/main/java/com/team10/backend/domain/order/dto/confirm/TossConfirmResponse.java
+++ b/src/main/java/com/team10/backend/domain/order/dto/confirm/TossConfirmResponse.java
@@ -3,6 +3,6 @@ package com.team10.backend.domain.order.dto.confirm;
 public record TossConfirmResponse(
         String paymentKey,
          String orderId,
-        String orderStatus
+        String status
 ) {
 }

--- a/src/main/java/com/team10/backend/domain/order/dto/webhook/WebhookPayload.java
+++ b/src/main/java/com/team10/backend/domain/order/dto/webhook/WebhookPayload.java
@@ -1,0 +1,14 @@
+package com.team10.backend.domain.order.dto.webhook;
+
+//https://docs.tosspayments.com/reference/using-api/webhook-events#payment_status_changed
+public record WebhookPayload(
+        String eventType, // PAYMENTS_STATUS_CHANGED 등
+        Data data
+) {
+    public record Data(
+            String paymentKey,
+            String orderId,
+            String status, // DONE, CANCELED, PARTIAL_CANCELED 등
+            Long totalAmount
+    ) {}
+}

--- a/src/main/java/com/team10/backend/domain/order/entity/Order.java
+++ b/src/main/java/com/team10/backend/domain/order/entity/Order.java
@@ -112,4 +112,8 @@ public class Order extends BaseEntity {
         // 만약 별도의 OrderStatus 필드가 있다면 CANCEL로 변경
          this.status = OrderStatus.CANCELED;
     }
+    public void successStatusOrder() {
+        // 만약 별도의 OrderStatus 필드가 있다면 CANCEL로 변경
+        this.status = OrderStatus.SUCCESS;
+    }
 }

--- a/src/main/java/com/team10/backend/domain/order/repository/OrderDeliveryRepository.java
+++ b/src/main/java/com/team10/backend/domain/order/repository/OrderDeliveryRepository.java
@@ -1,0 +1,7 @@
+package com.team10.backend.domain.order.repository;
+
+import com.team10.backend.domain.order.entity.OrderDelivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderDeliveryRepository extends JpaRepository<OrderDelivery,Long> {
+}

--- a/src/main/java/com/team10/backend/domain/order/repository/PaymentRepository.java
+++ b/src/main/java/com/team10/backend/domain/order/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.team10.backend.domain.order.repository;
+
+import com.team10.backend.domain.order.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment,Long> {
+    Optional<Payment> findByOrderNumber(String s);
+}

--- a/src/main/java/com/team10/backend/domain/order/service/OrderConfirmService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/OrderConfirmService.java
@@ -56,7 +56,12 @@ public class OrderConfirmService {
         String encodedKey = Base64.getEncoder().encodeToString((secretKey + ":").getBytes());
         //todo 네트워크가 끊겼을때 다시 시도할 경우 같은 orderNumber 키로 접근하면 오류가 발생한다.
         //그래서 orderNumber 뒤에 숫자를 붙여서 새로운 값을 사용. 그 값은 DB에 저장되어야 한다.(필드에 추가)
-        headers.set("Idempotency-Key", request.orderNumber() + (testCode != null ? UUID.randomUUID() : ""));
+        int attempt = RetrySynchronizationManager.getContext() != null
+                ? RetrySynchronizationManager.getContext().getRetryCount()
+                : 0;
+        String idempotencyKey = request.orderId() + "-v" + attempt;
+
+        headers.set("Idempotency-Key", idempotencyKey+ (testCode != null ? UUID.randomUUID() : ""));
         headers.set("Authorization", "Basic " + encodedKey);
         headers.setContentType(MediaType.APPLICATION_JSON);
 
@@ -64,11 +69,13 @@ public class OrderConfirmService {
 
         try {
             ResponseEntity<TossConfirmResponse> response = restTemplate.postForEntity(TOSS_URL + "/confirm", entity, TossConfirmResponse.class);
+            log.info("응답값 확인 {},{}",response,response.getBody());
             return response.getBody();
         } catch (HttpClientErrorException e) {
             // 비즈니스 로직 에러 (4xx)
             // 사용자의 잔액 부족, 카드 정보 오류 등
             String errorBody = e.getResponseBodyAsString();
+            log.info("에러 바디 확인: {}", errorBody); // 추가
             handleBusinessError(e.getStatusCode(), errorBody);
             return null; // unreachable (예외가 던져짐)
 
@@ -91,9 +98,9 @@ public class OrderConfirmService {
 
     // 최종적으로 사용자에게 실패 응답을 던지거나,
     @Recover
-    public TossConfirmResponse recover(Exception e, ConfirmRequest request, String errorCode,String idempotencyKey) {
+    public TossConfirmResponse recover(ResourceAccessException e, ConfirmRequest request,String testCode) {
        log.error("결제 승인 최종 실패 - 모든 재시도 소진. 주문번호: {}, 에러: {}",
-                request.orderNumber(), e.getMessage());
+                request.orderId(), e.getMessage());
 
        //todo 관리자에게 알람
         // 네트워크 장애 시: "결제 확인 중" 상태로 변경하거나 관리자 알림

--- a/src/main/java/com/team10/backend/domain/order/service/OrderConfirmService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/OrderConfirmService.java
@@ -43,8 +43,9 @@ public class OrderConfirmService {
 
         // 시크릿 키 인증 헤더 설정
         String encodedKey = Base64.getEncoder().encodeToString((secretKey + ":").getBytes());
-//        headers.set("Idempotency-Key", request.orderId());
-        headers.set("Idempotency-Key", UUID.randomUUID().toString());
+        //todo 네트워크가 끊겼을때 다시 시도할 경우 같은 orderNumber 키로 접근하면 오류가 발생한다.
+        //그래서 orderNumber 뒤에 숫자를 붙여서 새로운 값을 사용. 그 값은 DB에 저장되어야 한다.(필드에 추가)
+        headers.set("Idempotency-Key", request.orderNumber() + (testCode != null ? UUID.randomUUID() : ""));
         headers.set("Authorization", "Basic " + encodedKey);
         headers.setContentType(MediaType.APPLICATION_JSON);
 
@@ -71,8 +72,7 @@ public class OrderConfirmService {
         } catch (ResourceAccessException e) {
             // [네트워크 에러] - 타임아웃, 커넥션 거부 등
             //todo 1. 재시도 로직
-            //2. timeout GET 토스 조회 로직을 통해 현재 BE DB랑 정합성 비교
-            //3. WEBhook을 사용
+            //2. WEBhook을 사용
 
             log.error("네트워크 통신 실패: {}", e.getMessage());
 //            throw new BusinessException(ErrorCode.NETWORK_ERROR, "결제 서버와 통신이 원활하지 않습니다.");
@@ -82,6 +82,8 @@ public class OrderConfirmService {
 
     private void handleBusinessError(HttpStatusCode status, String errorBody) {
         String errorCode = parseErrorCode(errorBody);
+
+        log.error("토스페이먼츠 4xx 에러 발생 - Status: {}, Code: {}", status, errorCode);
 
         //404
         if (status.equals(HttpStatus.NOT_FOUND)) {
@@ -106,8 +108,6 @@ public class OrderConfirmService {
                     throw new BusinessException(FORBIDDEN_REQUEST);
                 case "INVALID_PASSWORD":
                     throw new BusinessException(INVALID_PASSWORD);
-//              default:
-//                    throw new BusinessException(ErrorCode.BAD_REQUEST, "결제 취소 요청이 거절되었습니다: " + errorCode);
             }
         }
 
@@ -140,10 +140,10 @@ public class OrderConfirmService {
     }
 
     private void handleSystemError(HttpStatusCode status, String errorBody) {
-        // JSON 파싱을 통해 토스의 "code"와 "message" 추출 (Jackson 등 이용)
+        // JSON 파싱을 통해 토스의 code와 message 추출
         String errorCode = parseErrorCode(errorBody);
 
-        log.error("토스페이먼츠 에러 발생 - Status: {}, Code: {}", status, errorCode);
+        log.error("토스페이먼츠 5xx 에러 발생 - Status: {}, Code: {}", status, errorCode);
 
         // 3. 토스 서버 및 은행 점검 문제 (500 계열)
         if (status.is5xxServerError()) {

--- a/src/main/java/com/team10/backend/domain/order/service/OrderConfirmService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/OrderConfirmService.java
@@ -2,7 +2,6 @@ package com.team10.backend.domain.order.service;
 
 import com.team10.backend.domain.order.dto.confirm.ConfirmRequest;
 import com.team10.backend.domain.order.dto.confirm.TossConfirmResponse;
-import com.team10.backend.global.dto.ApiResponse;
 import com.team10.backend.global.exception.BusinessException;
 import com.team10.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/team10/backend/domain/order/service/OrderConfirmService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/OrderConfirmService.java
@@ -1,0 +1,175 @@
+package com.team10.backend.domain.order.service;
+
+import com.team10.backend.domain.order.dto.confirm.ConfirmRequest;
+import com.team10.backend.domain.order.dto.confirm.TossConfirmResponse;
+import com.team10.backend.global.dto.ApiResponse;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Base64;
+import java.util.UUID;
+
+import static com.team10.backend.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderConfirmService {
+
+    @Value("${custom.toss.payment.secret-key}")
+    private String secretKey;
+
+    private final String TOSS_URL = "https://api.tosspayments.com/v1/payments";
+    private final ObjectMapper objectMapper;
+
+    public TossConfirmResponse sendConfirmRequest(ConfirmRequest request,String testCode) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+
+        if (testCode != null) {
+            headers.add("TossPayments-Test-Code", testCode);
+        }
+
+        // 시크릿 키 인증 헤더 설정
+        String encodedKey = Base64.getEncoder().encodeToString((secretKey + ":").getBytes());
+//        headers.set("Idempotency-Key", request.orderId());
+        headers.set("Idempotency-Key", UUID.randomUUID().toString());
+        headers.set("Authorization", "Basic " + encodedKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+
+        HttpEntity<ConfirmRequest> entity = new HttpEntity<>(request, headers);
+
+        try {
+            ResponseEntity<TossConfirmResponse> response = restTemplate.postForEntity(TOSS_URL + "/confirm", entity, TossConfirmResponse.class);
+            return response.getBody();
+        } catch (HttpClientErrorException e) {
+            // 비즈니스 로직 에러 (4xx)
+            // 사용자의 잔액 부족, 카드 정보 오류 등
+            String errorBody = e.getResponseBodyAsString();
+            handleBusinessError(e.getStatusCode(), errorBody);
+            return null; // unreachable (예외가 던져짐)
+
+        } catch (HttpServerErrorException e) {
+            // 시스템 및 서버 에러 (5xx)
+            // 토스 서버 장애, 은행 점검 등
+            String errorBody = e.getResponseBodyAsString();
+            handleSystemError(e.getStatusCode(), errorBody);
+            return null;
+
+        } catch (ResourceAccessException e) {
+            // [네트워크 에러] - 타임아웃, 커넥션 거부 등
+            //todo 1. 재시도 로직
+            //2. timeout GET 토스 조회 로직을 통해 현재 BE DB랑 정합성 비교
+            //3. WEBhook을 사용
+
+            log.error("네트워크 통신 실패: {}", e.getMessage());
+//            throw new BusinessException(ErrorCode.NETWORK_ERROR, "결제 서버와 통신이 원활하지 않습니다.");
+            return null;
+        }
+    }
+
+    private void handleBusinessError(HttpStatusCode status, String errorBody) {
+        String errorCode = parseErrorCode(errorBody);
+
+        //404
+        if (status.equals(HttpStatus.NOT_FOUND)) {
+            switch (errorCode) {
+                case "NOT_FOUND_PAYMENT" :
+                    throw new BusinessException(NOT_FOUND_PAYMENT );
+                case "NOT_FOUND_PAYMENT_SESSION":
+                    throw new BusinessException(NOT_FOUND_PAYMENT_SESSION);
+            }
+        }
+
+        // 403Forbidden: 권한이나 상태에 따른 거절
+        if (status.equals(HttpStatus.FORBIDDEN)) {
+            switch (errorCode) {
+                case "REJECT_ACCOUNT_PAYMENT" :
+                    throw new BusinessException(REJECT_ACCOUNT_PAYMENT);
+                case "REJECT_CARD_PAYMENT":
+                    throw new BusinessException(REJECT_CARD_PAYMENT);
+                case "REJECT_CARD_COMPANY":
+                    throw new BusinessException(REJECT_CARD_COMPANY);
+                case "FORBIDDEN_REQUEST":
+                    throw new BusinessException(FORBIDDEN_REQUEST);
+                case "INVALID_PASSWORD":
+                    throw new BusinessException(INVALID_PASSWORD);
+//              default:
+//                    throw new BusinessException(ErrorCode.BAD_REQUEST, "결제 취소 요청이 거절되었습니다: " + errorCode);
+            }
+        }
+
+        // 400 Bad Request:
+        if (status.equals(HttpStatus.BAD_REQUEST)) {
+            switch (errorCode) {
+                case "ALREADY_PROCESSED_PAYMENT" :
+                    throw new BusinessException(ALREADY_PROCESSED_PAYMENT);
+                case "INVALID_REQUEST":
+                    throw new BusinessException(INVALID_REQUEST);
+                case "INVALID_API_KEY":
+                    throw new BusinessException(INVALID_API_KEY);
+                case "INVALID_REJECT_CARD":
+                    throw new BusinessException(INVALID_REJECT_CARD );
+                case "INVALID_CARD_EXPIRATION":
+                    throw new BusinessException(INVALID_CARD_EXPIRATION );
+                case "INVALID_STOPPED_CARD":
+                    throw new BusinessException(INVALID_STOPPED_CARD );
+                case "INVALID_CARD_LOST_OR_STOLEN":
+                    throw new BusinessException(INVALID_CARD_LOST_OR_STOLEN );
+                 case "INVALID_CARD_NUMBER":
+                    throw new BusinessException(INVALID_CARD_NUMBER );
+                 case "INVALID_ACCOUNT_INFO_RE_REGISTER":
+                    throw new BusinessException(INVALID_ACCOUNT_INFO_RE_REGISTER);
+                 case "UNAPPROVED_ORDER_ID":
+                    throw new BusinessException(UNAPPROVED_ORDER_ID);
+            }
+        }
+
+    }
+
+    private void handleSystemError(HttpStatusCode status, String errorBody) {
+        // JSON 파싱을 통해 토스의 "code"와 "message" 추출 (Jackson 등 이용)
+        String errorCode = parseErrorCode(errorBody);
+
+        log.error("토스페이먼츠 에러 발생 - Status: {}, Code: {}", status, errorCode);
+
+        // 3. 토스 서버 및 은행 점검 문제 (500 계열)
+        if (status.is5xxServerError()) {
+            // 이 경우 트랜잭션을 롤백시켜 DB 주문 삭제를 막아야 함
+            switch (errorCode) {
+                case "FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING":
+                    throw new BusinessException(FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING);
+                case "UNKNOWN_PAYMENT_ERROR":
+                    throw new BusinessException(UNKNOWN_PAYMENT_ERROR);
+                case "FAILED_INTERNAL_SYSTEM_PROCESSING":
+                    throw new BusinessException(FAILED_INTERNAL_SYSTEM_PROCESSING );
+            }
+        }
+    }
+
+    private String parseErrorCode(String errorBody) {
+        try {
+            // 1. String 형태의 JSON을 JsonNode 객체로 읽는다.
+            JsonNode root = objectMapper.readTree(errorBody);
+
+            // 2. "code" 필드의 값을 텍스트로 가져온다
+            return root.path("code").asText();
+        } catch (Exception e) {
+            // 파싱 실패 시 로깅 후 기본 에러 코드 반환
+            log.error("토스 에러 응답 파싱 중 오류 발생: {}", e.getMessage());
+            return "UNKNOWN_ERROR";
+        }
+    }
+}

--- a/src/main/java/com/team10/backend/domain/order/service/OrderConfirmService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/OrderConfirmService.java
@@ -9,6 +9,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.support.RetrySynchronizationManager;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
@@ -33,8 +37,15 @@ public class OrderConfirmService {
     private final String TOSS_URL = "https://api.tosspayments.com/v1/payments";
     private final ObjectMapper objectMapper;
 
+    private final RestTemplate restTemplate;
+
+    // 1. 재시도 로직
+    @Retryable(
+            value = { ResourceAccessException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
     public TossConfirmResponse sendConfirmRequest(ConfirmRequest request,String testCode) {
-        RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
 
         if (testCode != null) {
@@ -48,7 +59,6 @@ public class OrderConfirmService {
         headers.set("Idempotency-Key", request.orderNumber() + (testCode != null ? UUID.randomUUID() : ""));
         headers.set("Authorization", "Basic " + encodedKey);
         headers.setContentType(MediaType.APPLICATION_JSON);
-
 
         HttpEntity<ConfirmRequest> entity = new HttpEntity<>(request, headers);
 
@@ -71,13 +81,23 @@ public class OrderConfirmService {
 
         } catch (ResourceAccessException e) {
             // [네트워크 에러] - 타임아웃, 커넥션 거부 등
-            //todo 1. 재시도 로직
+            //1. 재시도 로직
             //2. WEBhook을 사용
-
             log.error("네트워크 통신 실패: {}", e.getMessage());
-//            throw new BusinessException(ErrorCode.NETWORK_ERROR, "결제 서버와 통신이 원활하지 않습니다.");
-            return null;
+            throw e;
         }
+    }
+
+
+    // 최종적으로 사용자에게 실패 응답을 던지거나,
+    @Recover
+    public TossConfirmResponse recover(Exception e, ConfirmRequest request, String errorCode,String idempotencyKey) {
+       log.error("결제 승인 최종 실패 - 모든 재시도 소진. 주문번호: {}, 에러: {}",
+                request.orderNumber(), e.getMessage());
+
+       //todo 관리자에게 알람
+        // 네트워크 장애 시: "결제 확인 중" 상태로 변경하거나 관리자 알림
+        throw new BusinessException(ErrorCode.NETWORK_ERROR_FINAL_FAILED);
     }
 
     private void handleBusinessError(HttpStatusCode status, String errorBody) {

--- a/src/main/java/com/team10/backend/domain/order/service/PaymentService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/PaymentService.java
@@ -10,6 +10,7 @@ import com.team10.backend.domain.order.repository.OrderRepository;
 import com.team10.backend.domain.order.repository.PaymentRepository;
 import com.team10.backend.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,7 @@ import static com.team10.backend.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
@@ -27,17 +29,18 @@ public class PaymentService {
     @Transactional
     public TossConfirmResponse confirmPayment(ConfirmRequest request) {
         // 1. 비즈니스 검증: DB의 금액과 요청 금액 비교 , 주문 생성시에
-        Payment payment = paymentRepository.findByOrderNumber(request.orderNumber())
+        log.info("조회 시도 - request.orderId: [{}]", request.orderId());
+        Payment payment = paymentRepository.findByOrderNumber(request.orderId())
                 .orElseThrow(() -> new BusinessException(PAYMENT_NOT_FOUND));
 
-        Order order = orderRepository.findByOrderNumber(request.orderNumber())
+        Order order = orderRepository.findByOrderNumber(request.orderId())
                 .orElseThrow(() -> new BusinessException(ORDER_NOT_FOUND));
 
         OrderDelivery delivery = orderDeliveryRepository.findById(order.getId())
                 .orElseThrow(() -> new BusinessException(DELIVERY_NOT_FOUND));
 
         //프론트에서 금액을 위조했을 경우
-        if (payment.getTotalAmount()!=request.totalAmout()) {
+        if (payment.getTotalAmount()!=request.amount()) {
             throw new BusinessException(AMOUNT_MISMATCH);
         }
 
@@ -46,14 +49,23 @@ public class PaymentService {
         TossConfirmResponse response = orderConfirmService.sendConfirmRequest(request,null);
 
         // 3. 결제 성공 후 상태 변경 (후처리)
-        completePayment(payment, request.paymentKey());
-        updateOrderStatus(order);
-        startReady(delivery);
+        statusChangeAfterSuccess(payment,request.paymentKey(),order,delivery);
 
         return response;
     }
 
+    public void statusChangeAfterSuccess(Payment payment, String paymentKey, Order order, OrderDelivery delivery) {
+        completePayment(payment, paymentKey);
+        updateOrderStatus(order);
+        startReady(delivery);
+
+         paymentRepository.save(payment);
+         orderRepository.save(order);
+        orderDeliveryRepository.save(delivery);
+    }
+
     private void completePayment(Payment payment, String paymentKey) {
+        log.info("결제 완료 처리 시작: {}", paymentKey);
         payment.completePayment(paymentKey);
     }
 

--- a/src/main/java/com/team10/backend/domain/order/service/PaymentService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/PaymentService.java
@@ -1,0 +1,67 @@
+package com.team10.backend.domain.order.service;
+
+import com.team10.backend.domain.order.dto.confirm.ConfirmRequest;
+import com.team10.backend.domain.order.dto.confirm.TossConfirmResponse;
+import com.team10.backend.domain.order.entity.Order;
+import com.team10.backend.domain.order.entity.OrderDelivery;
+import com.team10.backend.domain.order.entity.Payment;
+import com.team10.backend.domain.order.repository.OrderDeliveryRepository;
+import com.team10.backend.domain.order.repository.OrderRepository;
+import com.team10.backend.domain.order.repository.PaymentRepository;
+import com.team10.backend.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.team10.backend.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+    private final OrderDeliveryRepository orderDeliveryRepository;
+    private final OrderConfirmService orderConfirmService; // 외부 API 호출 컴포넌트
+
+    @Transactional
+    public TossConfirmResponse confirmPayment(ConfirmRequest request) {
+        // 1. 비즈니스 검증: DB의 금액과 요청 금액 비교 , 주문 생성시에
+        Payment payment = paymentRepository.findByOrderNumber(request.orderNumber())
+                .orElseThrow(() -> new BusinessException(PAYMENT_NOT_FOUND));
+
+        Order order = orderRepository.findByOrderNumber(request.orderNumber())
+                .orElseThrow(() -> new BusinessException(ORDER_NOT_FOUND));
+
+        OrderDelivery delivery = orderDeliveryRepository.findById(order.getId())
+                .orElseThrow(() -> new BusinessException(DELIVERY_NOT_FOUND));
+
+        //프론트에서 금액을 위조했을 경우
+        if (payment.getTotalAmount()!=request.totalAmout()) {
+            throw new BusinessException(AMOUNT_MISMATCH);
+        }
+
+        // 2. 토스 서버로 승인 요청 (외부 통신)
+        // paymentKey, orderId, amount를 헤더와 함께 전송
+        TossConfirmResponse response = orderConfirmService.sendConfirmRequest(request,null);
+
+        // 3. 결제 성공 후 상태 변경 (후처리)
+        completePayment(payment, request.paymentKey());
+        updateOrderStatus(order);
+        startReady(delivery);
+
+        return response;
+    }
+
+    private void completePayment(Payment payment, String paymentKey) {
+        payment.completePayment(paymentKey);
+    }
+
+    private void updateOrderStatus(Order order) {
+        order.successStatusOrder();
+    }
+
+    private void startReady(OrderDelivery delivery) {
+        delivery.startReady();
+    }
+}

--- a/src/main/java/com/team10/backend/domain/order/service/PaymentWebhookService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/PaymentWebhookService.java
@@ -1,0 +1,62 @@
+package com.team10.backend.domain.order.service;
+
+import com.team10.backend.domain.order.dto.webhook.WebhookPayload;
+import com.team10.backend.domain.order.entity.Order;
+import com.team10.backend.domain.order.entity.OrderDelivery;
+import com.team10.backend.domain.order.entity.Payment;
+import com.team10.backend.domain.order.enums.OrderStatus;
+import com.team10.backend.domain.order.repository.OrderDeliveryRepository;
+import com.team10.backend.domain.order.repository.OrderRepository;
+import com.team10.backend.domain.order.repository.PaymentRepository;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.team10.backend.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentWebhookService {
+
+    private final OrderRepository orderRepository; // 주문 DB 내역
+    private final PaymentRepository paymentRepository;
+    private final OrderDeliveryRepository orderDeliveryRepository;
+    private final PaymentService paymentService;
+
+    @Transactional
+    public void processWebhook(WebhookPayload payload) {
+        String orderId = payload.data().orderId();
+        //웹훅에서 가져온 상태값 => 토스 서버
+        String newStatus = payload.data().status(); // DONE,CANCELED,EXPIRED,ABORTED,
+
+        // 1. DB에서 해당 주문 조회
+        Order order = orderRepository.findByOrderNumber(orderId)
+                .orElseThrow(() -> new BusinessException(ORDER_NOT_FOUND));
+
+        // 2. 멱등성 및 상태 체크
+        // 이미 DB에서 완료(success)된 주문인데 웹훅이 또 왔다면 무시
+        if (order.getStatus()== OrderStatus.SUCCESS && "DONE".equals(newStatus)) {
+            log.info("이미 처리된 웹훅입니다. orderId={}", orderId);
+            return;
+        }
+
+        // 3. DB가 SUCCESS가 아닌 상태 => 상태 업데이트 (주문 DB와 토스 DB 동기화)
+        if ("DONE".equals(newStatus)) {
+            // 토스 서버는 DONE인데, 우리 DB는 PENDING 상태
+            // 결제 완료 처리 로직 (재고 감소)
+            Payment payment = paymentRepository.findByOrderNumber(orderId)
+                    .orElseThrow(() -> new BusinessException(PAYMENT_NOT_FOUND));
+            OrderDelivery delivery = orderDeliveryRepository.findById(order.getId())
+                    .orElseThrow(() -> new BusinessException(DELIVERY_NOT_FOUND));
+            paymentService.statusChangeAfterSuccess(payment,payload.data().paymentKey(),order,delivery);
+        } else if ("CANCELED".equals(newStatus)) {
+            // 결제 취소 처리
+        }
+
+        log.info("주문 상태 업데이트 완료: orderId={}, status={}", orderId, newStatus);
+    }
+}

--- a/src/main/java/com/team10/backend/global/config/AppConfig.java
+++ b/src/main/java/com/team10/backend/global/config/AppConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class AppConfig {
@@ -13,4 +14,8 @@ public class AppConfig {
         return new BCryptPasswordEncoder();
     }
 
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 }

--- a/src/main/java/com/team10/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/team10/backend/global/exception/ErrorCode.java
@@ -44,9 +44,43 @@ public enum ErrorCode {
 
     //=== 결제 도메인(6000~6999) ===
     PAYMENT_NOT_FOUND("PAYMENT_001","결제 정보가 존재하지 않습니다.",HttpStatus.NOT_FOUND),
+    AMOUNT_MISMATCH("PAYMENT_002","결제 금액이 일치하지 않습니다. 위변조 위험이 있습니다.", HttpStatus.BAD_REQUEST),
 
     //=== 배송 도메인(7000~7999) ===
-    CANNOT_CANCEL_SHIPPING_ORDER("DELIVERY_01","이미 출고된 상품은 취소할 수 없습니다.",HttpStatus.BAD_REQUEST);
+    CANNOT_CANCEL_SHIPPING_ORDER("DELIVERY_01","이미 출고된 상품은 취소할 수 없습니다.",HttpStatus.BAD_REQUEST),
+    DELIVERY_NOT_FOUND("DELIVERY_02","배송 정보를 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
+
+    //====토스 외부 API 예외처리=====
+    // -------승인 비즈니스 오류(400,404,403)-----
+    //404
+    NOT_FOUND_PAYMENT("TOSS_01","존재하지 않는 결제 정보 입니다.",HttpStatus.NOT_FOUND),
+    NOT_FOUND_PAYMENT_SESSION("TOSS_02","결제 시간이 만료되어 결제 진행 데이터가 존재하지 않습니다.",HttpStatus.NOT_FOUND),
+
+    //403
+    REJECT_ACCOUNT_PAYMENT("TOSS_03","잔액부족으로 결제에 실패했습니다.",HttpStatus.FORBIDDEN),
+    REJECT_CARD_PAYMENT("TOSS_04","한도초과 혹은 잔액부족으로 결제에 실패했습니다.",HttpStatus.FORBIDDEN),
+    REJECT_CARD_COMPANY("TOSS_05","결제 승인이 거절되었습니다.",HttpStatus.FORBIDDEN),
+    FORBIDDEN_REQUEST("TOSS_06", "허용되지 않은 요청입니다.",HttpStatus.FORBIDDEN),
+    INVALID_PASSWORD("TOSS_07", "결제 비밀번호가 일치하지 않습니다.",HttpStatus.FORBIDDEN),
+
+    //400
+    ALREADY_PROCESSED_PAYMENT("TOSS_08", "이미 처리된 결제 입니다.",HttpStatus.BAD_REQUEST),
+    INVALID_REQUEST("TOSS_09",  "잘못된 요청입니다.",HttpStatus.BAD_REQUEST),
+    INVALID_API_KEY("TOSS_10",   "잘못된 시크릿키 연동 정보 입니다.",HttpStatus.BAD_REQUEST),
+    INVALID_REJECT_CARD("TOSS_11",   "카드 사용이 거절되었습니다. 카드사 문의가 필요합니다.",HttpStatus.BAD_REQUEST),
+    INVALID_CARD_EXPIRATION("TOSS_12",   "카드 정보를 다시 확인해주세요. (유효기간)",HttpStatus.BAD_REQUEST),
+    INVALID_STOPPED_CARD("TOSS_13",   "정지된 카드 입니다.",HttpStatus.BAD_REQUEST),
+    INVALID_CARD_LOST_OR_STOLEN("TOSS_14",   "분실 혹은 도난 카드입니다.",HttpStatus.BAD_REQUEST),
+    INVALID_CARD_NUMBER("TOSS_15",   "카드번호를 다시 확인해주세요.",HttpStatus.BAD_REQUEST),
+    INVALID_ACCOUNT_INFO_RE_REGISTER("TOSS_16",    "유효하지 않은 계좌입니다. 계좌 재등록 후 시도해주세요.",HttpStatus.BAD_REQUEST),
+    UNAPPROVED_ORDER_ID("TOSS_17",    "아직 승인되지 않은 주문번호입니다.",HttpStatus.BAD_REQUEST),
+    //----승인 시스템 오류(토스측 오류, 500,401..)-----
+    FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING("TOSS_18","결제가 완료되지 않았어요. 다시 시도해주세요.",HttpStatus.INTERNAL_SERVER_ERROR),
+    UNKNOWN_PAYMENT_ERROR("TOSS_19", "내부 시스템 처리 작업이 실패했습니다. 잠시 후 다시 시도해주세요",HttpStatus.INTERNAL_SERVER_ERROR),
+    FAILED_INTERNAL_SYSTEM_PROCESSING("TOSS_20", "결제에 실패했어요. 같은 문제가 반복된다면 은행이나 카드사로 문의해주세요.",HttpStatus.INTERNAL_SERVER_ERROR),
+    //-----네트워크 오류 ------
+    //503 서버가 현재 요청을 처리할 수 없음 (일시적 부하 또는 통신 장애).
+    NETWORK_ERROR_FINAL_FAILED("NETWORK_01","결제 결과를 확인할 수 없습니다. 중복 결제를 방지하기 위해 잠시 후 결제 내역을 확인해 주세요.",HttpStatus.SERVICE_UNAVAILABLE);
 
 
     private final String code;        // 프론트에서 분기용 비즈니스 코드

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -18,3 +18,6 @@ custom:
   jwt:
     secretKey: RjnNJn0bpT1nvG1AgH2vbTOvkB1iMzlX3+Evusj2n/U=
     expireTime: 1
+  toss:
+    payment:
+      secret-key: test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,6 +27,9 @@ custom:
   jwt:
     secretKey: ${SECRET_KEY}
     expireTime: 15
+  toss:
+    payment:
+      secret-key: test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6 # 공용 시크릿 키라 노출되어도 괜찮습니다.
 
 cloud:
   aws:

--- a/src/test/java/com/team10/backend/domain/order/controller/OrderConfirmServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/order/controller/OrderConfirmServiceTest.java
@@ -11,20 +11,25 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
 class OrderConfirmServiceTest {
-
+    private final String TOSS_URL = "https://api.tosspayments.com/v1/payments";
     @Autowired
     private OrderConfirmService orderConfirmService;
 
@@ -34,29 +39,79 @@ class OrderConfirmServiceTest {
     @ParameterizedTest
     @ValueSource(strings = {"REJECT_ACCOUNT_PAYMENT", "REJECT_CARD_PAYMENT", "REJECT_CARD_COMPANY", "FORBIDDEN_REQUEST", "INVALID_PASSWORD"})
     @DisplayName("403 Forbidden 관련 모든 에러 케이스 검증")
-    void confirmPayment_fail_forbiddenGroup(String errorCode) {
+    void confirmPayment_fail_forbiddenGroup2(String errorCode) {
+        // 1. Given: RestTemplate이 HttpClientErrorException(403)을 던지도록 설정
         ConfirmRequest request = new ConfirmRequest("test_key", "order_id", 5000L);
 
-        BusinessException exception = assertThrows(BusinessException.class, () -> {
+        // Toss 에러 응답 바디 시뮬레이션 (ErrorCode.name()이 포함되도록)
+        String errorResponseBody = "{\"code\":\"" + errorCode + "\", \"message\":\"테스트 에러\"}";
+
+        HttpClientErrorException forbiddenException = HttpClientErrorException.create(
+                HttpStatus.FORBIDDEN,
+                "Forbidden",
+                HttpHeaders.EMPTY,
+                errorResponseBody.getBytes(),
+                StandardCharsets.UTF_8
+        );
+
+        // restTemplate 호출 시 에러 발생시킴
+        when(restTemplate.postForEntity(anyString(), any(), eq(TossConfirmResponse.class)))
+                .thenThrow(forbiddenException);
+
+        // 2. When & Then
+        // 1. ExhaustedRetryException이 발생함을 기대함
+        Exception exception = assertThrows(Exception.class, () -> {
             orderConfirmService.sendConfirmRequest(request, errorCode);
         });
 
-        assertEquals(errorCode, exception.getErrorCode().name());
+        // 2. 만약 Retry가 개입했다면 원본 에러(getCause)를 확인
+        Throwable actualException = exception;
+        if (exception instanceof org.springframework.retry.ExhaustedRetryException) {
+            actualException = exception.getCause();
+        }
+
+        // 3. 최종 검증
+        assertTrue(actualException instanceof BusinessException);
+        assertEquals(errorCode, ((BusinessException) actualException).getErrorCode().name());
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"NOT_FOUND_PAYMENT", "NOT_FOUND_PAYMENT_SESSION"})
     @DisplayName("404 Not Found 관련 모든 에러 케이스 검증")
     void confirmPayment_fail_notFoundGroup(String errorCode) {
-        // given
+        // 1. Given: RestTemplate이 HttpClientErrorException(404)을 던지도록 설정
         ConfirmRequest request = new ConfirmRequest("test_key", "order_id", 5000L);
 
-        // when & then
-        BusinessException exception = assertThrows(BusinessException.class, () -> {
+        // Toss 에러 응답 바디 시뮬레이션
+        String errorResponseBody = "{\"code\":\"" + errorCode + "\", \"message\":\"테스트 에러\"}";
+
+        HttpClientErrorException notFoundException = HttpClientErrorException.create(
+                HttpStatus.NOT_FOUND,
+                "Not Found",
+                HttpHeaders.EMPTY,
+                errorResponseBody.getBytes(),
+                StandardCharsets.UTF_8
+        );
+
+        // restTemplate 호출 시 404 에러 발생시킴
+        when(restTemplate.postForEntity(anyString(), any(), eq(TossConfirmResponse.class)))
+                .thenThrow(notFoundException);
+
+        // 2. When & Then
+        // Retry 설정이 되어 있을 수 있으므로 상위 Exception으로 잡은 뒤 원본 에러를 확인합니다.
+        Exception exception = assertThrows(Exception.class, () -> {
             orderConfirmService.sendConfirmRequest(request, errorCode);
         });
 
-        assertEquals(errorCode, exception.getErrorCode().name());
+        // 만약 Retry가 개입했다면 원본 에러(getCause)를 추출
+        Throwable actualException = exception;
+        if (exception instanceof org.springframework.retry.ExhaustedRetryException) {
+            actualException = exception.getCause();
+        }
+
+        // 3. 최종 검증: BusinessException 여부와 내부 에러 코드 확인
+        assertTrue(actualException instanceof BusinessException);
+        assertEquals(errorCode, ((BusinessException) actualException).getErrorCode().name());
     }
 
     @ParameterizedTest
@@ -74,16 +129,39 @@ class OrderConfirmServiceTest {
     })
     @DisplayName("400 Bad Request 관련 모든 에러 케이스 검증")
     void confirmPayment_fail_badRequestGroup(String errorCode) {
-        // given
+        // 1. Given: RestTemplate이 HttpClientErrorException(400)을 던지도록 설정
         ConfirmRequest request = new ConfirmRequest("test_key", "order_id", 5000L);
 
-        // when & then
-        BusinessException exception = assertThrows(BusinessException.class, () -> {
+        // Toss 에러 응답 바디 시뮬레이션 (ErrorCode 포함)
+        String errorResponseBody = "{\"code\":\"" + errorCode + "\", \"message\":\"테스트 에러(400)\"}";
+
+        HttpClientErrorException badRequestException = HttpClientErrorException.create(
+                HttpStatus.BAD_REQUEST,
+                "Bad Request",
+                HttpHeaders.EMPTY,
+                errorResponseBody.getBytes(),
+                StandardCharsets.UTF_8
+        );
+
+        // restTemplate 호출 시 400 에러 발생 모킹
+        when(restTemplate.postForEntity(anyString(), any(), eq(TossConfirmResponse.class)))
+                .thenThrow(badRequestException);
+
+        // 2. When & Then
+        // Retry 발생 가능성을 염두에 두어 최상위 Exception으로 포착
+        Exception exception = assertThrows(Exception.class, () -> {
             orderConfirmService.sendConfirmRequest(request, errorCode);
         });
 
-        // 발생한 에러 코드가 입력한 에러 코드와 일치하는지 검증
-        assertEquals(errorCode, exception.getErrorCode().name());
+        // 만약 Retry 정책에 의해 감싸져 있다면 내부 원인(BusinessException)을 확인
+        Throwable actualException = exception;
+        if (exception instanceof org.springframework.retry.ExhaustedRetryException) {
+            actualException = exception.getCause();
+        }
+
+        // 3. 최종 검증
+        assertTrue(actualException instanceof BusinessException, "발생한 예외는 BusinessException이어야 합니다.");
+        assertEquals(errorCode, ((BusinessException) actualException).getErrorCode().name());
     }
 
     @ParameterizedTest
@@ -94,16 +172,40 @@ class OrderConfirmServiceTest {
     })
     @DisplayName("500 Server Error 관련 모든 에러 케이스 검증")
     void confirmPayment_fail_serverErrorGroup(String errorCode) {
-        // given
+        // 1. Given: RestTemplate이 HttpServerErrorException(500)을 던지도록 설정
         ConfirmRequest request = new ConfirmRequest("test_key", "order_id", 5000L);
 
-        // when & then
-        // BusinessException이 발생해야 하며, 에러 코드가 일치해야 함
-        BusinessException exception = assertThrows(BusinessException.class, () -> {
+        // Toss 에러 응답 바디 시뮬레이션
+        String errorResponseBody = "{\"code\":\"" + errorCode + "\", \"message\":\"서버 내부 에러(500)\"}";
+
+        // 500 에러를 명시적으로 생성 (HttpServerErrorException)
+        HttpServerErrorException serverErrorException = HttpServerErrorException.create(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Internal Server Error",
+                HttpHeaders.EMPTY,
+                errorResponseBody.getBytes(),
+                StandardCharsets.UTF_8
+        );
+
+        // restTemplate 호출 시 500 에러 발생 모킹
+        when(restTemplate.postForEntity(anyString(), any(), eq(TossConfirmResponse.class)))
+                .thenThrow(serverErrorException);
+
+        // 2. When & Then
+        // Retry 발생 가능성을 염두에 두어 Exception으로 포착
+        Exception exception = assertThrows(Exception.class, () -> {
             orderConfirmService.sendConfirmRequest(request, errorCode);
         });
 
-        assertEquals(errorCode, exception.getErrorCode().name());
+        // Retry에 의해 감싸져 있다면 원본 BusinessException 추출
+        Throwable actualException = exception;
+        if (exception instanceof org.springframework.retry.ExhaustedRetryException) {
+            actualException = exception.getCause();
+        }
+
+        // 3. 최종 검증
+        assertTrue(actualException instanceof BusinessException, "발생한 예외는 BusinessException이어야 합니다.");
+        assertEquals(errorCode, ((BusinessException) actualException).getErrorCode().name());
     }
 
     @Test

--- a/src/test/java/com/team10/backend/domain/order/controller/OrderConfirmServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/order/controller/OrderConfirmServiceTest.java
@@ -1,0 +1,99 @@
+package com.team10.backend.domain.order.controller;
+
+import com.team10.backend.domain.order.dto.confirm.ConfirmRequest;
+import com.team10.backend.domain.order.service.OrderConfirmService;
+import com.team10.backend.global.exception.BusinessException;
+import com.team10.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class OrderConfirmServiceTest {
+
+    @Autowired
+    private OrderConfirmService orderConfirmService;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"REJECT_ACCOUNT_PAYMENT", "REJECT_CARD_PAYMENT", "REJECT_CARD_COMPANY", "FORBIDDEN_REQUEST", "INVALID_PASSWORD"})
+    @DisplayName("403 Forbidden 관련 모든 에러 케이스 검증")
+    void confirmPayment_fail_forbiddenGroup(String errorCode) {
+        ConfirmRequest request = new ConfirmRequest("test_key", "order_id", 5000L);
+
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            orderConfirmService.sendConfirmRequest(request, errorCode);
+        });
+
+        assertEquals(errorCode, exception.getErrorCode().name());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"NOT_FOUND_PAYMENT", "NOT_FOUND_PAYMENT_SESSION"})
+    @DisplayName("404 Not Found 관련 모든 에러 케이스 검증")
+    void confirmPayment_fail_notFoundGroup(String errorCode) {
+        // given
+        ConfirmRequest request = new ConfirmRequest("test_key", "order_id", 5000L);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            orderConfirmService.sendConfirmRequest(request, errorCode);
+        });
+
+        assertEquals(errorCode, exception.getErrorCode().name());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ALREADY_PROCESSED_PAYMENT",
+            "INVALID_REQUEST",
+            "INVALID_API_KEY",
+            "INVALID_REJECT_CARD",
+            "INVALID_CARD_EXPIRATION",
+            "INVALID_STOPPED_CARD",
+            "INVALID_CARD_LOST_OR_STOLEN",
+            "INVALID_CARD_NUMBER",
+            "INVALID_ACCOUNT_INFO_RE_REGISTER",
+            "UNAPPROVED_ORDER_ID"
+    })
+    @DisplayName("400 Bad Request 관련 모든 에러 케이스 검증")
+    void confirmPayment_fail_badRequestGroup(String errorCode) {
+        // given
+        ConfirmRequest request = new ConfirmRequest("test_key", "order_id", 5000L);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            orderConfirmService.sendConfirmRequest(request, errorCode);
+        });
+
+        // 발생한 에러 코드가 입력한 에러 코드와 일치하는지 검증
+        assertEquals(errorCode, exception.getErrorCode().name());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING",
+            "UNKNOWN_PAYMENT_ERROR",
+            "FAILED_INTERNAL_SYSTEM_PROCESSING"
+    })
+    @DisplayName("500 Server Error 관련 모든 에러 케이스 검증")
+    void confirmPayment_fail_serverErrorGroup(String errorCode) {
+        // given
+        ConfirmRequest request = new ConfirmRequest("test_key", "order_id", 5000L);
+
+        // when & then
+        // BusinessException이 발생해야 하며, 에러 코드가 일치해야 함
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            orderConfirmService.sendConfirmRequest(request, errorCode);
+        });
+
+        assertEquals(errorCode, exception.getErrorCode().name());
+    }
+}

--- a/src/test/java/com/team10/backend/domain/order/controller/OrderConfirmServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/order/controller/OrderConfirmServiceTest.java
@@ -1,6 +1,7 @@
 package com.team10.backend.domain.order.controller;
 
 import com.team10.backend.domain.order.dto.confirm.ConfirmRequest;
+import com.team10.backend.domain.order.dto.confirm.TossConfirmResponse;
 import com.team10.backend.domain.order.service.OrderConfirmService;
 import com.team10.backend.global.exception.BusinessException;
 import com.team10.backend.global.exception.ErrorCode;
@@ -11,9 +12,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -21,6 +27,9 @@ class OrderConfirmServiceTest {
 
     @Autowired
     private OrderConfirmService orderConfirmService;
+
+    @MockitoBean
+    private RestTemplate restTemplate; // 서비스 내부에서 사용하는 RestTemplate을 가로챔
 
     @ParameterizedTest
     @ValueSource(strings = {"REJECT_ACCOUNT_PAYMENT", "REJECT_CARD_PAYMENT", "REJECT_CARD_COMPANY", "FORBIDDEN_REQUEST", "INVALID_PASSWORD"})
@@ -95,5 +104,29 @@ class OrderConfirmServiceTest {
         });
 
         assertEquals(errorCode, exception.getErrorCode().name());
+    }
+
+    @Test
+    @DisplayName("네트워크 에러 발생 시 3번 재시도 후 Recover가 실행되는지 테스트")
+    void retry_three_times_and_recover() {
+        // given
+        ConfirmRequest request = new ConfirmRequest("order_123", "key_abc", 5000L);
+
+        // restTemplate이 호출될 때마다 ResourceAccessException을 던지도록 설정
+        // (재시도 횟수인 3번만큼 예외를 발생시킴)
+        when(restTemplate.postForEntity(anyString(), any(), eq(TossConfirmResponse.class)))
+                .thenThrow(new ResourceAccessException("Network Timeout"));
+
+        // when & then
+        // 1. 최종적으로 BusinessException이 발생하는지 확인
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            orderConfirmService.sendConfirmRequest(request, null);
+        });
+
+        // 2. 에러 코드가 네트워크 최종 실패인지 확인
+        assertEquals(ErrorCode.NETWORK_ERROR_FINAL_FAILED, exception.getErrorCode());
+
+        // 3. 실제로 restTemplate이 3번 호출되었는지 검증
+        verify(restTemplate, times(3)).postForEntity(anyString(), any(), eq(TossConfirmResponse.class));
     }
 }

--- a/src/test/java/com/team10/backend/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/order/controller/OrderControllerTest.java
@@ -194,6 +194,35 @@ public class OrderControllerTest {
     }
 
     @Test
+    @DisplayName("단일 상품 주문 생성 성공")
+    void t1_3() throws Exception {
+        // Given: 요청 데이터 준비
+        // 상품101(1만)x2 + 상품102(2만)x2 + 상품103(3만)x2
+        OrderCreateRequest.OrderProductReq item1 = new OrderCreateRequest.OrderProductReq(101L, 2);
+        // 예상 총 금액: (10000*2)
+        int expectedTotalAmount = 20000;
+
+        OrderCreateRequest req = new OrderCreateRequest(1L, "서울특별시 강남구 테헤란로", List.of(item1));
+        System.out.println(orderService.createOrder(req));
+        // When: 호출 (실제 서비스의 createOrder가 실행됨)
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/v1/orders")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(req))
+                )
+                .andDo(print());
+
+        // Then: 검증
+        // 이제 mockResponse가 아니라 실제 서비스가 계산해서 반환한 값이 검증됩니다.
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1L))
+                .andExpect(jsonPath("$.data.totalAmount").value(expectedTotalAmount)) // 실제 계산 결과 검증
+                .andExpect(jsonPath("$.data.orderNumber").exists());
+    }
+
+    @Test
     @DisplayName("주문 생성 실패 - 필수 입력값 누락 (Validation)")
     void t2() throws Exception {
         // Given: 주소가 비어있고 상품이 없는 잘못된 요청


### PR DESCRIPTION
## 📌 개요 (What)]

- 토스 페이먼츠에서 주문 검증하는 부분을 구현합니다.
- webhook을 연결합니다. 

## ✨ 작업 내용

- [ ] 토스 페이먼츠에서 검증하는 /confirm을 만듭니다
- [ ] 외부 api와 연동하고 발생할 수 있는 예외처리를 합니다.
- [ ] webhook을 연결합니다.

## 🔥 변경 이유

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

좀 급하게 올리느라 paymentService 테스트 코드 작성이 안되어있습니다. 이건 새로 이슈를 따서 만들도록 하겠습니다. 

기능적으로 문제가 없습니다. 간단한 html파일로 테스트 해본 결과 결제까지는 성공적으로 진행됩니다. 

 아까는 웹 훅 부분에서 막혔었는데, 조금 더 찾아보니까 코드 자체 문제가 아니라 토스 api 키 연결하는 문제가 있었던 것 같습니다. (이건 좀 더 해결 방법을 찾아보겠습니다)

curl -X POST "https://6678-211-110-71-156.ngrok-free.app/api/v1/payments/webhook" -H "Content-Type: application/json" -d "{\"eventType\":\"PAYMENT_STATUS_CHANGED\",\"data\":{\"orderId\":\"ORD-20260421-c5392d54\",\"status\":\"DONE\"}}"
해당 코드를 cmd에서 webhook 주소로 전송할 때는 성공적으로 값이 찍히는 것을 확인해서 말씀드립니다.

## 🔗 관련 이슈
- close #64
