### PR TITLE
feat: add presigned image upload flow

### DIFF
--- a/src/main/java/com/team10/backend/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/team10/backend/domain/feed/controller/FeedController.java
@@ -1,7 +1,7 @@
 package com.team10.backend.domain.feed.controller;
 
 import com.team10.backend.domain.feed.dto.post.CreateFeedRequestDto;
-import com.team10.backend.domain.feed.dto.post.CreateFeedResponseDto;
+import com.team10.backend.domain.feed.dto.post.FeedResponseDto;
 import com.team10.backend.domain.feed.dto.post.FeedLikeToggleResponseDto;
 import com.team10.backend.domain.feed.dto.post.FeedListResponseDto;
 import com.team10.backend.domain.feed.dto.post.UpdateFeedRequestDto;
@@ -48,11 +48,11 @@ public class FeedController {
     @PostMapping("me/feeds")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "피드 생성", description = "판매자가 피드를 생성 합니다.")
-    public ApiResponse<CreateFeedResponseDto> createFeed(
+    public ApiResponse<FeedResponseDto> createFeed(
             @RequestBody @Valid CreateFeedRequestDto requestDto,
             @AuthenticationPrincipal CustomUserPrincipal seller
             ) {
-        CreateFeedResponseDto responseDto = feedPostService.createFeed(requestDto, seller.userId());
+        FeedResponseDto responseDto = feedPostService.createFeed(requestDto, seller.userId());
         return ApiResponse.ok(responseDto);
     }
 

--- a/src/main/java/com/team10/backend/domain/feed/dto/post/FeedResponseDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/post/FeedResponseDto.java
@@ -1,0 +1,23 @@
+package com.team10.backend.domain.feed.dto.post;
+
+import com.team10.backend.domain.feed.entity.FeedPost;
+
+import java.util.List;
+
+public record FeedResponseDto(
+        Long feedId,
+        String content,
+        List<String> mediaUrls,
+        String createdAt
+) {
+    public static FeedResponseDto from(FeedPost feedPost) {
+        return new FeedResponseDto(
+                feedPost.getId(),
+                feedPost.getContent(),
+                feedPost.getImageUrl() != null && !feedPost.getImageUrl().isBlank()
+                        ? List.of(feedPost.getImageUrl())
+                        : List.of(),
+                feedPost.getCreatedAt().toString()
+        );
+    }
+}

--- a/src/main/java/com/team10/backend/domain/feed/entity/FeedPost.java
+++ b/src/main/java/com/team10/backend/domain/feed/entity/FeedPost.java
@@ -22,7 +22,7 @@ import java.util.List;
 @Table(name = "feed_posts")
 public class FeedPost extends BaseEntity {
 
-    @Column(nullable = false)
+    @Column
     private String imageUrl;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/team10/backend/domain/feed/service/FeedPostService.java
+++ b/src/main/java/com/team10/backend/domain/feed/service/FeedPostService.java
@@ -1,7 +1,7 @@
 package com.team10.backend.domain.feed.service;
 
 import com.team10.backend.domain.feed.dto.post.CreateFeedRequestDto;
-import com.team10.backend.domain.feed.dto.post.CreateFeedResponseDto;
+import com.team10.backend.domain.feed.dto.post.FeedResponseDto;
 import com.team10.backend.domain.feed.dto.post.FeedDto;
 import com.team10.backend.domain.feed.dto.post.FeedLikeToggleResponseDto;
 import com.team10.backend.domain.feed.dto.post.FeedListResponseDto;
@@ -55,7 +55,7 @@ public class FeedPostService {
 
     @Transactional
     // 피드는 판매자만 생성할 수 있다.
-    public CreateFeedResponseDto createFeed(CreateFeedRequestDto requestDto, Long currentUserId) {
+    public FeedResponseDto createFeed(CreateFeedRequestDto requestDto, Long currentUserId) {
         User currentUser = getUser(currentUserId);
         validateSeller(currentUser);
 
@@ -66,7 +66,7 @@ public class FeedPostService {
         );
 
         FeedPost savedFeed = feedPostRepository.save(feedPost);
-        return CreateFeedResponseDto.from(savedFeed);
+        return FeedResponseDto.from(savedFeed);
     }
 
     @Transactional
@@ -161,7 +161,14 @@ public class FeedPostService {
     private String extractThumbnailUrl(CreateFeedRequestDto requestDto) {
         return requestDto.mediaUrls() != null && !requestDto.mediaUrls().isEmpty()
                 ? requestDto.mediaUrls().getFirst()
-                : "";
+                : null;
+    }
+
+    // 수정 요청에서도 대표 이미지로 첫 번째 URL만 사용한다.
+    private String extractThumbnailUrl(UpdateFeedRequestDto requestDto) {
+        return requestDto.mediaUrls() != null && !requestDto.mediaUrls().isEmpty()
+                ? requestDto.mediaUrls().getFirst()
+                : null;
     }
 
     // 현재 로그인 사용자의 좋아요 여부를 포함해 FeedDto로 변환한다.
@@ -178,13 +185,6 @@ public class FeedPostService {
 
         return feed.getFeedLikes().stream()
                 .anyMatch(like -> like.getUser().getId().equals(currentUser.getId()));
-    }
-
-    // 수정 요청에서도 대표 이미지로 첫 번째 URL만 사용한다.
-    private String extractThumbnailUrl(UpdateFeedRequestDto requestDto) {
-        return requestDto.mediaUrls() != null && !requestDto.mediaUrls().isEmpty()
-                ? requestDto.mediaUrls().getFirst()
-                : "";
     }
 
     // 좋아요가 이미 있으면 취소하고, 없으면 새로 생성한다.

--- a/src/main/java/com/team10/backend/domain/image/controller/ImageUploadController.java
+++ b/src/main/java/com/team10/backend/domain/image/controller/ImageUploadController.java
@@ -1,19 +1,25 @@
 package com.team10.backend.domain.image.controller;
 
 import com.team10.backend.domain.image.dto.ImageUploadResponse;
+import com.team10.backend.domain.image.dto.PresignedUrlRequest;
+import com.team10.backend.domain.image.dto.PresignedUrlResponse;
 import com.team10.backend.domain.image.service.ImageUploadService;
 import com.team10.backend.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,13 +29,35 @@ public class ImageUploadController {
 
     private final ImageUploadService imageUploadService;
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, params = "file")
     @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "이미지 업로드", description = "이미지를 S3에 업로드하고 접근 URL을 반환합니다.")
+    @Operation(summary = "이미지 단일 업로드", description = "이미지를 S3에 업로드하고 접근 URL을 반환합니다.")
     public ApiResponse<ImageUploadResponse> upload(
             @RequestParam MultipartFile file,
             @RequestParam(defaultValue = "images") String directory
     ) {
         return ApiResponse.ok(imageUploadService.upload(file, directory));
     }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, params = "files")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "이미지 다중 업로드", description = "다중 이미지를 S3에 업로드하고 접근 URL을 반환합니다.")
+    public ApiResponse<List<ImageUploadResponse>> uploadMultiple(
+            @RequestParam List<MultipartFile> files,
+            @RequestParam(defaultValue = "images") String directory
+    ) {
+        List<ImageUploadResponse> response =
+                imageUploadService.uploadMultiple(files, directory);
+        
+        return ApiResponse.ok(response);
+    }
+
+    @PostMapping("/presigned-url")
+    @Operation(summary = "Presigned URL 발급", description = "프론트가 S3에 직접 업로드할 수 있는 URL과 저장용 이미지 URL을 반환합니다.")
+    public ApiResponse<PresignedUrlResponse> createPresignedUrl(
+            @RequestBody @Valid PresignedUrlRequest request
+    ) {
+        return ApiResponse.ok(imageUploadService.createPresignedUrl(request));
+    }
+
 }

--- a/src/main/java/com/team10/backend/domain/image/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/team10/backend/domain/image/dto/PresignedUrlRequest.java
@@ -1,0 +1,14 @@
+package com.team10.backend.domain.image.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PresignedUrlRequest(
+        @NotBlank(message = "파일명은 필수입니다.")
+        String fileName,
+
+        @NotBlank(message = "파일 타입은 필수입니다.")
+        String contentType,
+
+        String directory
+) {
+}

--- a/src/main/java/com/team10/backend/domain/image/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/team10/backend/domain/image/dto/PresignedUrlResponse.java
@@ -1,0 +1,7 @@
+package com.team10.backend.domain.image.dto;
+
+public record PresignedUrlResponse(
+        String uploadUrl,
+        String imageUrl
+) {
+}

--- a/src/main/java/com/team10/backend/domain/image/service/ImageUploadService.java
+++ b/src/main/java/com/team10/backend/domain/image/service/ImageUploadService.java
@@ -1,6 +1,8 @@
 package com.team10.backend.domain.image.service;
 
 import com.team10.backend.domain.image.dto.ImageUploadResponse;
+import com.team10.backend.domain.image.dto.PresignedUrlRequest;
+import com.team10.backend.domain.image.dto.PresignedUrlResponse;
 import com.team10.backend.global.exception.BusinessException;
 import com.team10.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -9,16 +11,21 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
-import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -26,6 +33,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Slf4j
 public class ImageUploadService {
+
+    private static final Duration PRESIGNED_URL_DURATION = Duration.ofMinutes(5);
 
     private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
             "image/jpeg",
@@ -35,6 +44,7 @@ public class ImageUploadService {
     );
 
     private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -58,7 +68,6 @@ public class ImageUploadService {
                 .build();
 
         try {
-            // MultipartFile의 실제 바이트 스트림을 S3 object로 업로드한다.
             s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
         } catch (IOException | SdkException e) {
             log.error("S3 image upload failed. bucket={}, key={}, reason={}", bucketName, key, e.getMessage(), e);
@@ -66,6 +75,40 @@ public class ImageUploadService {
         }
 
         return new ImageUploadResponse(createImageUrl(key));
+    }
+
+    // 다중 이미지 파일을 S3에 업로드하고, DB에 저장할 수 있는 리스트를 반환
+    public List<ImageUploadResponse> uploadMultiple(List<MultipartFile> files, String directory) {
+        validateFiles(files);
+
+        return files.stream()
+                .map(file -> upload(file, directory))
+                .toList();
+    }
+
+    public PresignedUrlResponse createPresignedUrl(PresignedUrlRequest request) {
+        validatePresignedUrlRequest(request);
+
+        String key = createObjectKey(request.fileName(), request.directory());
+        String bucketName = bucket.trim();
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(request.contentType())
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(PRESIGNED_URL_DURATION)
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+
+        return new PresignedUrlResponse(
+                presignedRequest.url().toString(),
+                createImageUrl(key)
+        );
     }
 
     // imageUrl에서 S3 object key를 추출해 실제 S3 파일을 삭제한다.
@@ -81,13 +124,17 @@ public class ImageUploadService {
                 .bucket(bucketName)
                 .key(key)
                 .build();
-
         try {
             s3Client.deleteObject(request);
         } catch (SdkException e) {
             log.error("S3 image delete failed. bucket={}, key={}, reason={}", bucketName, key, e.getMessage(), e);
             throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
         }
+    }
+
+    public void deleteMultiple(List<String> imageUrls) {
+        validateImageUrls(imageUrls);
+        imageUrls.forEach(this::deleteIfManaged);
     }
 
     // 피드/상품 수정 시 기존 이미지가 우리 S3 URL인 경우에만 삭제한다.
@@ -112,10 +159,45 @@ public class ImageUploadService {
         }
     }
 
+    private void validatePresignedUrlRequest(PresignedUrlRequest request) {
+        if (!StringUtils.hasText(bucket)) {
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED, "S3 버킷 설정이 없습니다.");
+        }
+        if (request == null || !StringUtils.hasText(request.fileName())) {
+            throw new BusinessException(ErrorCode.INVALID_IMAGE_FILE, "파일명은 필수입니다.");
+        }
+        if (!ALLOWED_CONTENT_TYPES.contains(request.contentType())) {
+            throw new BusinessException(ErrorCode.INVALID_IMAGE_FILE);
+        }
+    }
+
+    private void validateFiles(List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_IMAGE_FILE, "업로드할 이미지 파일이 없습니다.");
+        }
+
+        if (files.size() > 10) {
+            throw new BusinessException(ErrorCode.INVALID_IMAGE_FILE, "파일은 최대 10개 까지 업로드할 수 있습니다.");
+        }
+    }
+
+    private void validateImageUrls(List<String> imageUrls){
+        if (imageUrls == null || imageUrls.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "삭제할 이미지가 없습니다.");
+        }
+    }
+
+
     // S3 object key를 만든다. 예: feeds/{uuid}.jpg
     private String createObjectKey(MultipartFile file, String directory) {
         String safeDirectory = sanitizeDirectory(directory);
         String extension = getExtension(file.getOriginalFilename());
+        return safeDirectory + "/" + UUID.randomUUID() + extension;
+    }
+
+    private String createObjectKey(String fileName, String directory) {
+        String safeDirectory = sanitizeDirectory(directory);
+        String extension = getExtension(fileName);
         return safeDirectory + "/" + UUID.randomUUID() + extension;
     }
 

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -1,5 +1,6 @@
 package com.team10.backend.domain.product.service;
 
+import com.team10.backend.domain.image.service.ImageUploadService;
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.dto.ProductInactiveResponse;
@@ -28,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +37,7 @@ public class ProductService {
 
     private final UserRepository userRepository;
     private final ProductRepository productRepository;
+    private final ImageUploadService imageUploadService;
 
     @Transactional
     public ProductDetailResponse create(Long userId, ProductCreateRequest request) {
@@ -114,6 +117,7 @@ public class ProductService {
     public ProductDetailResponse update(Long userId, Long productId, ProductUpdateRequest request) {
 
         Product product = getAuthorizedProduct(userId, productId);
+        deletePreviousImageIfChanged(product.getImageUrl(), request.imageUrl());
 
         product.update(
                 request.type(),
@@ -165,6 +169,12 @@ public class ProductService {
         }
 
         return product;
+    }
+
+    private void deletePreviousImageIfChanged(String oldImageUrl, String newImageUrl) {
+        if (!Objects.equals(oldImageUrl, newImageUrl)) {
+            imageUploadService.deleteIfManaged(oldImageUrl);
+        }
     }
 
     private Product getAuthorizedProductWithLock(Long userId, Long productId) {

--- a/src/main/java/com/team10/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/team10/backend/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.team10.backend.domain.user.controller;
 
+import com.team10.backend.domain.user.dto.ProfileImageUpdateRequest;
 import com.team10.backend.domain.user.dto.SellerPublicResponse;
 import com.team10.backend.domain.user.dto.SellerResponse;
 import com.team10.backend.domain.user.dto.SellerUpdateRequest;
@@ -14,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -81,6 +83,33 @@ public class UserController {
         return ApiResponse.ok(response);
     }
 
+    @PutMapping("/users/me/profile-image")
+    @PreAuthorize("hasRole('BUYER')")
+    @Operation(
+            summary = "내 사용자 프로필 이미지 수정",
+            description = "로그인한 BUYER 본인의 프로필 이미지를 수정합니다.")
+    public ApiResponse<UserResponse> updateMyUserProfileImage(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @Valid @RequestBody ProfileImageUpdateRequest request
+    ) {
+        UserResponse response = userService.updateMyUserProfileImage(principal.userId(), request);
+
+        return ApiResponse.ok(response);
+    }
+
+    @DeleteMapping("/users/me/profile-image")
+    @PreAuthorize("hasRole('BUYER')")
+    @Operation(
+            summary = "내 사용자 프로필 이미지 삭제",
+            description = "로그인한 BUYER 본인의 프로필 이미지를 삭제합니다.")
+    public ApiResponse<UserResponse> deleteMyUserProfileImage(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        UserResponse response = userService.deleteMyUserProfileImage(principal.userId());
+
+        return ApiResponse.ok(response);
+    }
+
     @PutMapping("/sellers/me")
     @PreAuthorize("hasRole('SELLER')")
     @Operation(
@@ -95,5 +124,31 @@ public class UserController {
         return ApiResponse.ok(response);
     }
 
+    @PutMapping("/sellers/me/profile-image")
+    @PreAuthorize("hasRole('SELLER')")
+    @Operation(
+            summary = "내 판매자 프로필 이미지 수정",
+            description = "로그인한 SELLER 본인의 프로필 이미지를 수정합니다.")
+    public ApiResponse<SellerResponse> updateMySellerProfileImage(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @Valid @RequestBody ProfileImageUpdateRequest request
+    ) {
+        SellerResponse response = userService.updateMySellerProfileImage(principal.userId(), request);
+
+        return ApiResponse.ok(response);
+    }
+
+    @DeleteMapping("/sellers/me/profile-image")
+    @PreAuthorize("hasRole('SELLER')")
+    @Operation(
+            summary = "내 판매자 프로필 이미지 삭제",
+            description = "로그인한 SELLER 본인의 프로필 이미지를 삭제합니다.")
+    public ApiResponse<SellerResponse> deleteMySellerProfileImage(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        SellerResponse response = userService.deleteMySellerProfileImage(principal.userId());
+
+        return ApiResponse.ok(response);
+    }
 
 }

--- a/src/main/java/com/team10/backend/domain/user/dto/ProfileImageUpdateRequest.java
+++ b/src/main/java/com/team10/backend/domain/user/dto/ProfileImageUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.team10.backend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.URL;
+
+public record ProfileImageUpdateRequest(
+        @NotBlank(message = "이미지 URL은 필수입니다.")
+        @URL(message = "올바른 이미지 URL 형식이어야 합니다.")
+        String imageUrl
+) {
+}

--- a/src/main/java/com/team10/backend/domain/user/entity/User.java
+++ b/src/main/java/com/team10/backend/domain/user/entity/User.java
@@ -85,4 +85,8 @@ public class User extends BaseEntity {
         this.address = address;
     }
 
+    public void updateProfileImage(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
 }

--- a/src/main/java/com/team10/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/team10/backend/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.team10.backend.domain.user.service;
 
+import com.team10.backend.domain.image.service.ImageUploadService;
+import com.team10.backend.domain.user.dto.ProfileImageUpdateRequest;
 import com.team10.backend.domain.user.dto.SellerPublicResponse;
 import com.team10.backend.domain.user.dto.SellerResponse;
 import com.team10.backend.domain.user.dto.SellerUpdateRequest;
@@ -14,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 import static com.team10.backend.global.exception.ErrorCode.NOT_SELLER;
 import static com.team10.backend.global.exception.ErrorCode.USER_NOT_FOUND;
 
@@ -22,6 +26,7 @@ import static com.team10.backend.global.exception.ErrorCode.USER_NOT_FOUND;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ImageUploadService imageUploadService;
 
     @Transactional(readOnly = true)
     public UserResponse getUserProfile(Long userId) {
@@ -53,7 +58,7 @@ public class UserService {
                 request.nickname(),
                 request.phoneNumber(),
                 request.address()
-                );
+        );
 
         return UserResponse.from(user);
     }
@@ -79,9 +84,51 @@ public class UserService {
         return SellerResponse.from(user);
     }
 
+    @Transactional
+    public UserResponse updateMyUserProfileImage(Long id, ProfileImageUpdateRequest request) {
+        User user = getUserEntity(id);
+        updateProfileImage(user, request.imageUrl());
+
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public SellerResponse updateMySellerProfileImage(Long id, ProfileImageUpdateRequest request) {
+        User user = getUserEntity(id);
+        validateSellerRole(user);
+        updateProfileImage(user, request.imageUrl());
+
+        return SellerResponse.from(user);
+    }
+
+    @Transactional
+    public UserResponse deleteMyUserProfileImage(Long id) {
+        User user = getUserEntity(id);
+        updateProfileImage(user, null);
+
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public SellerResponse deleteMySellerProfileImage(Long id) {
+        User user = getUserEntity(id);
+        validateSellerRole(user);
+        updateProfileImage(user, null);
+
+        return SellerResponse.from(user);
+    }
+
     private User getUserEntity(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+    }
+
+    private void updateProfileImage(User user, String imageUrl) {
+        String oldImageUrl = user.getImageUrl();
+        if (!Objects.equals(oldImageUrl, imageUrl)) {
+            imageUploadService.deleteIfManaged(oldImageUrl);
+            user.updateProfileImage(imageUrl);
+        }
     }
 
     private void validateSellerRole(User user) {

--- a/src/main/java/com/team10/backend/global/config/S3Config.java
+++ b/src/main/java/com/team10/backend/global/config/S3Config.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -12,6 +13,13 @@ public class S3Config {
     @Bean
     public S3Client s3Client(@Value("${cloud.aws.region}") String region) {
         return S3Client.builder()
+                .region(Region.of(region))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(@Value("${cloud.aws.region}") String region) {
+        return S3Presigner.builder()
                 .region(Region.of(region))
                 .build();
     }

--- a/src/test/java/com/team10/backend/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/feed/controller/FeedControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -96,7 +97,32 @@ public class FeedControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isCreated()) // 201 확인
-                .andExpect(jsonPath("$.data.content").value("오늘의 새로운 소식!"));
+                .andExpect(jsonPath("$.data.content").value("오늘의 새로운 소식!"))
+                .andExpect(jsonPath("$.data.mediaUrls[0]").value("https://image.url/1"));
+
+        assertThat(feedPostRepository.findAll().getFirst().getImageUrl())
+                .isEqualTo("https://image.url/1");
+    }
+
+    @Test
+    @DisplayName("피드 등록 시 이미지가 없으면 imageUrl은 null")
+    void createFeed_withoutImageUrl() throws Exception {
+        String requestBody = """
+            {
+              "content": "이미지 없는 소식!",
+              "mediaUrls": []
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/stores/me/feeds")
+                        .with(authenticatedUser(1L, Role.SELLER))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.content").value("이미지 없는 소식!"))
+                .andExpect(jsonPath("$.data.mediaUrls").isEmpty());
+
+        assertThat(feedPostRepository.findAll().getFirst().getImageUrl()).isNull();
     }
 
     @Test

--- a/src/test/java/com/team10/backend/domain/feed/service/FeedPostServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/feed/service/FeedPostServiceTest.java
@@ -1,7 +1,7 @@
 package com.team10.backend.domain.feed.service;
 
 import com.team10.backend.domain.feed.dto.post.CreateFeedRequestDto;
-import com.team10.backend.domain.feed.dto.post.CreateFeedResponseDto;
+import com.team10.backend.domain.feed.dto.post.FeedResponseDto;
 import com.team10.backend.domain.feed.dto.post.FeedLikeToggleResponseDto;
 import com.team10.backend.domain.feed.dto.post.FeedListResponseDto;
 import com.team10.backend.domain.feed.dto.post.UpdateFeedRequestDto;
@@ -135,7 +135,7 @@ public class FeedPostServiceTest {
         );
 
 
-        CreateFeedResponseDto result = feedPostService.createFeed(requestDto, testUser.getId());
+        FeedResponseDto result = feedPostService.createFeed(requestDto, testUser.getId());
 
 
         assertThat(result.feedId()).isNotNull();

--- a/src/test/java/com/team10/backend/domain/image/service/ImageUploadServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/image/service/ImageUploadServiceTest.java
@@ -1,6 +1,8 @@
 package com.team10.backend.domain.image.service;
 
 import com.team10.backend.domain.image.dto.ImageUploadResponse;
+import com.team10.backend.domain.image.dto.PresignedUrlRequest;
+import com.team10.backend.domain.image.dto.PresignedUrlResponse;
 import com.team10.backend.global.exception.BusinessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,6 +11,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,16 +23,19 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ImageUploadServiceTest {
 
     private S3Client s3Client;
+    private S3Presigner s3Presigner;
     private ImageUploadService imageUploadService;
 
     @BeforeEach
     void setUp() {
         s3Client = mock(S3Client.class);
-        imageUploadService = new ImageUploadService(s3Client);
+        s3Presigner = mock(S3Presigner.class);
+        imageUploadService = new ImageUploadService(s3Client, s3Presigner);
         ReflectionTestUtils.setField(imageUploadService, "bucket", "team10-images-dev-test");
         ReflectionTestUtils.setField(imageUploadService, "region", "ap-northeast-2");
     }
@@ -45,6 +55,31 @@ class ImageUploadServiceTest {
                 .startsWith("https://team10-images-dev-test.s3.ap-northeast-2.amazonaws.com/products/")
                 .endsWith(".jpg");
         verify(s3Client).putObject(any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class));
+    }
+
+    @Test
+    void createPresignedUrlReturnsUploadUrlAndImageUrl() throws Exception {
+        PresignedPutObjectRequest presignedRequest = mock(PresignedPutObjectRequest.class);
+        when(presignedRequest.url()).thenReturn(URI.create("https://presigned-upload.test/upload").toURL());
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenReturn(presignedRequest);
+
+        PresignedUrlResponse response = imageUploadService.createPresignedUrl(
+                new PresignedUrlRequest("cake.jpg", "image/jpeg", "products")
+        );
+
+        assertThat(response.uploadUrl()).isEqualTo("https://presigned-upload.test/upload");
+        assertThat(response.imageUrl())
+                .startsWith("https://team10-images-dev-test.s3.ap-northeast-2.amazonaws.com/products/")
+                .endsWith(".jpg");
+        verify(s3Presigner).presignPutObject(any(PutObjectPresignRequest.class));
+    }
+
+    @Test
+    void createPresignedUrlRejectsNonImageContentType() {
+        PresignedUrlRequest request = new PresignedUrlRequest("memo.txt", "text/plain", "products");
+
+        assertThatThrownBy(() -> imageUploadService.createPresignedUrl(request))
+                .isInstanceOf(BusinessException.class);
     }
 
     @Test

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
@@ -123,6 +123,7 @@ class ProductCommandControllerTest {
                   "productName": "ABC",
                   "price": 10000,
                   "stock": 100,
+                  "imageUrl": "https://www.exam.com/product.jpg",
                   "type": "BOOK"
                 }
                 """;
@@ -142,6 +143,7 @@ class ProductCommandControllerTest {
                   "productName": "ABC",
                   "price": 10000,
                   "stock": 100,
+                  "imageUrl": "https://www.exam.com/product.jpg",
                   "type": "BOOK"
                 }
                 """;
@@ -155,6 +157,7 @@ class ProductCommandControllerTest {
                 .andExpect(jsonPath("$.data.productName").value("ABC"))
                 .andExpect(jsonPath("$.data.price").value(10000))
                 .andExpect(jsonPath("$.data.stock").value(100))
+                .andExpect(jsonPath("$.data.imageUrl").value("https://www.exam.com/product.jpg"))
                 .andExpect(jsonPath("$.data.type").value("BOOK"))
                 .andExpect(jsonPath("$.data.status").value("SELLING"));
 
@@ -165,6 +168,7 @@ class ProductCommandControllerTest {
         assertThat(product.getProductName()).isEqualTo("ABC");
         assertThat(product.getPrice()).isEqualTo(10000);
         assertThat(product.getStock()).isEqualTo(100);
+        assertThat(product.getImageUrl()).isEqualTo("https://www.exam.com/product.jpg");
         assertThat(product.getType()).isEqualTo(ProductType.BOOK);
         assertThat(product.getStatus()).isEqualTo(ProductStatus.SELLING);
         assertThat(product.getUser().getId()).isEqualTo(1L);

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -1,5 +1,6 @@
 package com.team10.backend.domain.product.service;
 
+import com.team10.backend.domain.image.service.ImageUploadService;
 import com.team10.backend.domain.product.dto.ProductCreateRequest;
 import com.team10.backend.domain.product.dto.ProductDetailResponse;
 import com.team10.backend.domain.product.dto.ProductInactiveResponse;
@@ -23,10 +24,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 @Transactional
@@ -44,6 +48,9 @@ class ProductServiceTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private ImageUploadService imageUploadService;
 
     @BeforeEach
     void setUp() {
@@ -104,6 +111,27 @@ class ProductServiceTest {
         assertThat(response.imageUrl()).isNull();
         assertThat(response.status()).isEqualTo(ProductStatus.SELLING);
         assertThat(productRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("상품 생성 시 imageUrl이 있으면 저장")
+    void createProduct_withImageUrl() {
+        ProductCreateRequest request = new ProductCreateRequest(
+                "이미지 상품",
+                "이미지 있는 상품입니다.",
+                10000,
+                100,
+                "https://example.com/product.jpg",
+                ProductType.BOOK
+        );
+
+        ProductDetailResponse response = productService.create(1L, request);
+
+        assertThat(response.productName()).isEqualTo("이미지 상품");
+        assertThat(response.imageUrl()).isEqualTo("https://example.com/product.jpg");
+
+        Product product = productRepository.findById(response.productId()).orElseThrow();
+        assertThat(product.getImageUrl()).isEqualTo("https://example.com/product.jpg");
     }
 
     @Test
@@ -245,6 +273,69 @@ class ProductServiceTest {
         assertThat(response.imageUrl()).isEqualTo("https://example.com/new.jpg");
         assertThat(response.type()).isEqualTo(ProductType.EBOOK);
         assertThat(response.status()).isEqualTo(ProductStatus.SOLD_OUT);
+        verify(imageUploadService).deleteIfManaged("https://example.com/old.jpg");
+    }
+
+    @Test
+    @DisplayName("상품 수정 시 imageUrl이 null이면 상품 이미지 삭제 - 성공")
+    void updateProduct_deleteImageWhenImageUrlIsNull_success() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://example.com/old.jpg"
+        ));
+
+        ProductUpdateRequest request = new ProductUpdateRequest(
+                "수정된 상품명",
+                "수정된 설명",
+                12000,
+                null,
+                ProductType.EBOOK,
+                ProductStatus.SELLING
+        );
+
+        ProductDetailResponse response = productService.update(1L, savedProduct.getId(), request);
+
+        assertThat(response.productId()).isEqualTo(savedProduct.getId());
+        assertThat(response.imageUrl()).isNull();
+        verify(imageUploadService).deleteIfManaged("https://example.com/old.jpg");
+    }
+
+    @Test
+    @DisplayName("상품 수정 시 imageUrl이 같으면 기존 이미지 삭제하지 않음")
+    void updateProduct_skipImageDeleteWhenImageUrlIsSame_success() {
+        User user = userRepository.findById(1L).orElseThrow();
+
+        Product savedProduct = productRepository.save(new Product(
+                user,
+                ProductType.BOOK,
+                "기존 상품명",
+                "기존 설명",
+                10000,
+                10,
+                "https://example.com/same.jpg"
+        ));
+
+        ProductUpdateRequest request = new ProductUpdateRequest(
+                "수정된 상품명",
+                "수정된 설명",
+                12000,
+                "https://example.com/same.jpg",
+                ProductType.EBOOK,
+                ProductStatus.SELLING
+        );
+
+        ProductDetailResponse response = productService.update(1L, savedProduct.getId(), request);
+
+        assertThat(response.productId()).isEqualTo(savedProduct.getId());
+        assertThat(response.imageUrl()).isEqualTo("https://example.com/same.jpg");
+        verify(imageUploadService, never()).deleteIfManaged("https://example.com/same.jpg");
     }
 
     @Test

--- a/src/test/java/com/team10/backend/domain/user/integration/UserIntegrationTest.java
+++ b/src/test/java/com/team10/backend/domain/user/integration/UserIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.team10.backend.domain.user.integration;
 
 import com.team10.backend.domain.user.controller.UserController;
+import com.team10.backend.domain.user.dto.ProfileImageUpdateRequest;
 import com.team10.backend.domain.user.dto.SellerUpdateRequest;
 import com.team10.backend.domain.user.dto.UserUpdateRequest;
 import com.team10.backend.domain.user.entity.User;
@@ -20,6 +21,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.ObjectMapper;
 
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -96,6 +99,53 @@ public class UserIntegrationTest {
     }
 
     @Test
+    @DisplayName("유저 프로필 이미지 수정 - 성공")
+    @WithMockUser(roles = "BUYER")
+    void updateUserProfileImage_success() throws Exception {
+        User user = UserTestFixture.createBuyer();
+        user.updateProfileImage("https://test.com/profile.jpg");
+        userRepository.save(user);
+
+        AuthTestHelper.setAuth(user);
+
+        ProfileImageUpdateRequest request =
+                new ProfileImageUpdateRequest("https://test.com/new-profile.jpg");
+
+        ResultActions resultActions = mvc.perform(
+                        put("/api/v1/users/me/profile-image")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(UserController.class))
+                .andExpect(handler().methodName("updateMyUserProfileImage"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.imageUrl").value("https://test.com/new-profile.jpg"));
+    }
+
+    @Test
+    @DisplayName("유저 프로필 이미지 삭제 - 성공")
+    @WithMockUser(roles = "BUYER")
+    void deleteUserProfileImage_success() throws Exception {
+        User user = UserTestFixture.createBuyer();
+        user.updateProfileImage("https://test.com/profile.jpg");
+        userRepository.save(user);
+
+        AuthTestHelper.setAuth(user);
+
+        ResultActions resultActions = mvc.perform(delete("/api/v1/users/me/profile-image"))
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(UserController.class))
+                .andExpect(handler().methodName("deleteMyUserProfileImage"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.imageUrl").value(nullValue()));
+    }
+
+    @Test
     @DisplayName("판매자 API 접근 실패 - BUYER")
     @WithMockUser(roles = "BUYER")
     void getSellerProfile_fail() throws Exception {
@@ -164,5 +214,52 @@ public class UserIntegrationTest {
                 .andExpect(jsonPath("$.data.nickname").value("새로운판매자"))
                 .andExpect(jsonPath("$.data.bio").value("새로운 소개입니다"))
                 .andExpect(jsonPath("$.data.businessNumber").value("999-99-99999"));
+    }
+
+    @Test
+    @DisplayName("판매자 프로필 이미지 수정 - 성공")
+    @WithMockUser(roles = "SELLER")
+    void updateSellerProfileImage_success() throws Exception {
+        User user = UserTestFixture.createSeller();
+        user.updateProfileImage("https://test.com/seller-profile.jpg");
+        userRepository.save(user);
+
+        AuthTestHelper.setAuth(user);
+
+        ProfileImageUpdateRequest request =
+                new ProfileImageUpdateRequest("https://test.com/new-seller-profile.jpg");
+
+        ResultActions resultActions = mvc.perform(
+                        put("/api/v1/sellers/me/profile-image")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(UserController.class))
+                .andExpect(handler().methodName("updateMySellerProfileImage"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.imageUrl").value("https://test.com/new-seller-profile.jpg"));
+    }
+
+    @Test
+    @DisplayName("판매자 프로필 이미지 삭제 - 성공")
+    @WithMockUser(roles = "SELLER")
+    void deleteSellerProfileImage_success() throws Exception {
+        User user = UserTestFixture.createSeller();
+        user.updateProfileImage("https://test.com/seller-profile.jpg");
+        userRepository.save(user);
+
+        AuthTestHelper.setAuth(user);
+
+        ResultActions resultActions = mvc.perform(delete("/api/v1/sellers/me/profile-image"))
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(UserController.class))
+                .andExpect(handler().methodName("deleteMySellerProfileImage"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.imageUrl").value(nullValue()));
     }
 }

--- a/src/test/java/com/team10/backend/domain/user/unit/UserServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/user/unit/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.team10.backend.domain.user.unit;
 
+import com.team10.backend.domain.image.service.ImageUploadService;
+import com.team10.backend.domain.user.dto.ProfileImageUpdateRequest;
 import com.team10.backend.domain.user.dto.SellerResponse;
 import com.team10.backend.domain.user.dto.SellerUpdateRequest;
 import com.team10.backend.domain.user.dto.UserResponse;
@@ -14,14 +16,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.Optional;
 
 import static com.team10.backend.global.exception.ErrorCode.NOT_SELLER;
 import static com.team10.backend.global.exception.ErrorCode.USER_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,6 +32,9 @@ public class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private ImageUploadService imageUploadService;
 
     @InjectMocks
     private UserService userService;
@@ -85,6 +91,7 @@ public class UserServiceTest {
     void updateMyUserProfile_success() {
         // given
         User user = UserTestFixture.createBuyer();
+        user.updateProfileImage("https://old-image.test/profile.jpg");
 
         UserUpdateRequest request = new UserUpdateRequest(
                 "새로운닉네임",
@@ -103,6 +110,38 @@ public class UserServiceTest {
         assertEquals("010-9999-9999", response.phoneNumber());
         assertEquals("부산", response.address());
     }
+
+    @Test
+    @DisplayName("사용자 프로필 이미지 수정 - 성공")
+    void updateMyUserProfileImage_success() {
+        User user = UserTestFixture.createBuyer();
+        user.updateProfileImage("https://old-image.test/profile.jpg");
+
+        ProfileImageUpdateRequest request =
+                new ProfileImageUpdateRequest("https://new-image.test/profile.jpg");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        UserResponse response = userService.updateMyUserProfileImage(1L, request);
+
+        assertEquals("https://new-image.test/profile.jpg", response.imageUrl());
+        verify(imageUploadService).deleteIfManaged("https://old-image.test/profile.jpg");
+    }
+
+    @Test
+    @DisplayName("사용자 프로필 이미지 삭제 - 성공")
+    void deleteMyUserProfileImage_success() {
+        User user = UserTestFixture.createBuyer();
+        user.updateProfileImage("https://old-image.test/profile.jpg");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        UserResponse response = userService.deleteMyUserProfileImage(1L);
+
+        assertNull(response.imageUrl());
+        verify(imageUploadService).deleteIfManaged("https://old-image.test/profile.jpg");
+    }
+
     @Test
     @DisplayName("판매자 개인정보 수정 - 성공")
     void updateMySellerProfile_success() {


### PR DESCRIPTION
## 📌 개요 (What)
- S3 기반 이미지 업로드 기능을 정리하고, Presigned URL 방식을 추가했습니다.
- 프로필/상품/피드에서 업로드된 이미지 URL을 저장할 수 있도록 연결했으며, 프로필 이미지는 전용 수정 API로 분리했습니다.

## ✨ 작업 내용
- S3 이미지 업로드 API 정리
- POST /api/v1/images/presigned-url 추가
- Presigned URL 발급 후 S3 직접 업로드 가능하도록 구성
- 프로필 이미지 수정/삭제 API 분리
- 일반 프로필 수정 DTO에서 imageUrl 제거
- 상품 생성/수정 시 단일 imageUrl 저장 연동
- 피드 생성/수정 시 대표 이미지 1장 저장 연동
- 이미지 변경/삭제 시 기존 S3 이미지 정리 로직 반영
- 이미지가 없는 경우 DB에는 null 저장하도록 처리
- 관련 서비스/통합 테스트 보완

## 🔥 변경 이유
- 프론트가 S3에 직접 업로드할 수 있도록 Presigned URL 방식을 지원하기 위해
- 프로필 이미지 변경 UX를 일반 정보 수정과 분리하기 위해
- 이미지가 없는 상태를 기본 이미지 URL이 아닌 null로 명확히 표현하기 위해

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
- 이미지가 없는 경우 DB에는 null을 저장하고, 프론트엔드에서 기본 이미지를 표시.
- presigned url의 경우 다중 이미지는 추후에 수정가능

## 🔗 관련 이슈
- close #66
