### PR TITLE
refactor: 프로필 이미지 API 통합

### DIFF
--- a/src/main/java/com/team10/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/team10/backend/domain/user/controller/UserController.java
@@ -83,32 +83,6 @@ public class UserController {
         return ApiResponse.ok(response);
     }
 
-    @PutMapping("/users/me/profile-image")
-    @PreAuthorize("hasRole('BUYER')")
-    @Operation(
-            summary = "내 사용자 프로필 이미지 수정",
-            description = "로그인한 BUYER 본인의 프로필 이미지를 수정합니다.")
-    public ApiResponse<UserResponse> updateMyUserProfileImage(
-            @AuthenticationPrincipal CustomUserPrincipal principal,
-            @Valid @RequestBody ProfileImageUpdateRequest request
-    ) {
-        UserResponse response = userService.updateMyUserProfileImage(principal.userId(), request);
-
-        return ApiResponse.ok(response);
-    }
-
-    @DeleteMapping("/users/me/profile-image")
-    @PreAuthorize("hasRole('BUYER')")
-    @Operation(
-            summary = "내 사용자 프로필 이미지 삭제",
-            description = "로그인한 BUYER 본인의 프로필 이미지를 삭제합니다.")
-    public ApiResponse<UserResponse> deleteMyUserProfileImage(
-            @AuthenticationPrincipal CustomUserPrincipal principal
-    ) {
-        UserResponse response = userService.deleteMyUserProfileImage(principal.userId());
-
-        return ApiResponse.ok(response);
-    }
 
     @PutMapping("/sellers/me")
     @PreAuthorize("hasRole('SELLER')")
@@ -124,30 +98,28 @@ public class UserController {
         return ApiResponse.ok(response);
     }
 
-    @PutMapping("/sellers/me/profile-image")
-    @PreAuthorize("hasRole('SELLER')")
+    @PutMapping("/me/profile-image")
+    @PreAuthorize("isAuthenticated()")
     @Operation(
-            summary = "내 판매자 프로필 이미지 수정",
-            description = "로그인한 SELLER 본인의 프로필 이미지를 수정합니다.")
-    public ApiResponse<SellerResponse> updateMySellerProfileImage(
+            summary = "내 프로필 이미지 수정",
+            description = "로그인한 본인의 프로필 이미지를 수정합니다.")
+    public ApiResponse<UserResponse> updateMyProfileImage(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @Valid @RequestBody ProfileImageUpdateRequest request
     ) {
-        SellerResponse response = userService.updateMySellerProfileImage(principal.userId(), request);
-
+        UserResponse response = userService.updateMyProfileImage(principal.userId(), request);
         return ApiResponse.ok(response);
     }
 
-    @DeleteMapping("/sellers/me/profile-image")
-    @PreAuthorize("hasRole('SELLER')")
+    @DeleteMapping("/me/profile-image")
+    @PreAuthorize("isAuthenticated()")
     @Operation(
-            summary = "내 판매자 프로필 이미지 삭제",
-            description = "로그인한 SELLER 본인의 프로필 이미지를 삭제합니다.")
-    public ApiResponse<SellerResponse> deleteMySellerProfileImage(
+            summary = "내 프로필 이미지 삭제",
+            description = "로그인한 본인의 프로필 이미지를 삭제합니다.")
+    public ApiResponse<UserResponse> deleteMyProfileImage(
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        SellerResponse response = userService.deleteMySellerProfileImage(principal.userId());
-
+        UserResponse response = userService.deleteMyProfileImage(principal.userId());
         return ApiResponse.ok(response);
     }
 

--- a/src/main/java/com/team10/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/team10/backend/domain/user/service/UserService.java
@@ -85,37 +85,19 @@ public class UserService {
     }
 
     @Transactional
-    public UserResponse updateMyUserProfileImage(Long id, ProfileImageUpdateRequest request) {
+    public UserResponse updateMyProfileImage(Long id, ProfileImageUpdateRequest request) {
         User user = getUserEntity(id);
         updateProfileImage(user, request.imageUrl());
-
         return UserResponse.from(user);
     }
 
-    @Transactional
-    public SellerResponse updateMySellerProfileImage(Long id, ProfileImageUpdateRequest request) {
-        User user = getUserEntity(id);
-        validateSellerRole(user);
-        updateProfileImage(user, request.imageUrl());
-
-        return SellerResponse.from(user);
-    }
 
     @Transactional
-    public UserResponse deleteMyUserProfileImage(Long id) {
+    public UserResponse deleteMyProfileImage(Long id) {
         User user = getUserEntity(id);
         updateProfileImage(user, null);
 
         return UserResponse.from(user);
-    }
-
-    @Transactional
-    public SellerResponse deleteMySellerProfileImage(Long id) {
-        User user = getUserEntity(id);
-        validateSellerRole(user);
-        updateProfileImage(user, null);
-
-        return SellerResponse.from(user);
     }
 
     private User getUserEntity(Long userId) {

--- a/src/test/java/com/team10/backend/domain/user/integration/UserIntegrationTest.java
+++ b/src/test/java/com/team10/backend/domain/user/integration/UserIntegrationTest.java
@@ -112,7 +112,7 @@ public class UserIntegrationTest {
                 new ProfileImageUpdateRequest("https://test.com/new-profile.jpg");
 
         ResultActions resultActions = mvc.perform(
-                        put("/api/v1/users/me/profile-image")
+                        put("/api/v1/me/profile-image")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                 )
@@ -120,7 +120,7 @@ public class UserIntegrationTest {
 
         resultActions
                 .andExpect(handler().handlerType(UserController.class))
-                .andExpect(handler().methodName("updateMyUserProfileImage"))
+                .andExpect(handler().methodName("updateMyProfileImage"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.imageUrl").value("https://test.com/new-profile.jpg"));
     }
@@ -135,12 +135,12 @@ public class UserIntegrationTest {
 
         AuthTestHelper.setAuth(user);
 
-        ResultActions resultActions = mvc.perform(delete("/api/v1/users/me/profile-image"))
+        ResultActions resultActions = mvc.perform(delete("/api/v1/me/profile-image"))
                 .andDo(print());
 
         resultActions
                 .andExpect(handler().handlerType(UserController.class))
-                .andExpect(handler().methodName("deleteMyUserProfileImage"))
+                .andExpect(handler().methodName("deleteMyProfileImage"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.imageUrl").value(nullValue()));
     }
@@ -230,7 +230,7 @@ public class UserIntegrationTest {
                 new ProfileImageUpdateRequest("https://test.com/new-seller-profile.jpg");
 
         ResultActions resultActions = mvc.perform(
-                        put("/api/v1/sellers/me/profile-image")
+                        put("/api/v1/me/profile-image")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                 )
@@ -238,7 +238,7 @@ public class UserIntegrationTest {
 
         resultActions
                 .andExpect(handler().handlerType(UserController.class))
-                .andExpect(handler().methodName("updateMySellerProfileImage"))
+                .andExpect(handler().methodName("updateMyProfileImage"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.imageUrl").value("https://test.com/new-seller-profile.jpg"));
     }
@@ -253,12 +253,12 @@ public class UserIntegrationTest {
 
         AuthTestHelper.setAuth(user);
 
-        ResultActions resultActions = mvc.perform(delete("/api/v1/sellers/me/profile-image"))
+        ResultActions resultActions = mvc.perform(delete("/api/v1/me/profile-image"))
                 .andDo(print());
 
         resultActions
                 .andExpect(handler().handlerType(UserController.class))
-                .andExpect(handler().methodName("deleteMySellerProfileImage"))
+                .andExpect(handler().methodName("deleteMyProfileImage"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.imageUrl").value(nullValue()));
     }

--- a/src/test/java/com/team10/backend/domain/user/unit/UserServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/user/unit/UserServiceTest.java
@@ -122,7 +122,7 @@ public class UserServiceTest {
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
-        UserResponse response = userService.updateMyUserProfileImage(1L, request);
+        UserResponse response = userService.updateMyProfileImage(1L, request);
 
         assertEquals("https://new-image.test/profile.jpg", response.imageUrl());
         verify(imageUploadService).deleteIfManaged("https://old-image.test/profile.jpg");
@@ -136,7 +136,7 @@ public class UserServiceTest {
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
-        UserResponse response = userService.deleteMyUserProfileImage(1L);
+        UserResponse response = userService.deleteMyProfileImage(1L);
 
         assertNull(response.imageUrl());
         verify(imageUploadService).deleteIfManaged("https://old-image.test/profile.jpg");


### PR DESCRIPTION
## 📌 개요 (What)
구매자/판매자로 분리되어 있던 프로필 이미지 등록·삭제 API를 공통 구조 통합

## ✨ 작업 내용
- 이미지 등록 API 통합
- 이미지 삭제 API 통합
- 공통 요청/응답 구조에 맞게 컨트롤러 및 서비스 로직 수정
- 테스트코드 수정 
 
## 🔥 변경 이유
루매자와 판매자의 프로필 이미지 변경 기능은 동작 방식이 동일한데도 API가 분리되어 있어 중복 코드가 발생

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
- 현재는 프로필 이미지 기능을 공통 API로 통합

## 🔗 관련 이슈
- close #