### PR TITLE
feat: 주문 재고 동시성 제어 및 검증 테스트 추가

### DIFF
--- a/src/main/java/com/team10/backend/domain/order/service/OrderService.java
+++ b/src/main/java/com/team10/backend/domain/order/service/OrderService.java
@@ -89,10 +89,11 @@ public class OrderService {
     public List<OrderProducts> getOrderProductList(OrderCreateRequest request) {
         return request.orderProducts().stream()
                 .map(orderProdctReq->{
-                    Product product = productRepository.findById(orderProdctReq.productId())
+                    Product product = productRepository.findByIdWithPessimisticLock(orderProdctReq.productId())
                             .orElseThrow(() -> new BusinessException(PRODUCT_NOT_FOUND,"상품을 찾을 수 없습니다. ID: " + orderProdctReq.productId()));
 
                     //todo 재고 감소 로직
+                    product.decreaseStock(orderProdctReq.quantity());
 
                     //OrderProduct 테이블에 저장
                     return OrderProducts.builder()
@@ -192,6 +193,7 @@ public class OrderService {
         // 내부적으로 @SQLDelete가 작동하여 'is_deleted = true'로 업데이트함
         //주문 데이터가 삭제된것으로 변경된다. 하드 딜리트가 아니다.
         orderRepository.delete(order);
+        orderRepository.flush();
     }
 
     private void validateOrderDelete(Long userId, Order order) {
@@ -232,6 +234,12 @@ public class OrderService {
             // 필드명이 orderProducts 임을 확인하세요!
             order.getOrderProducts().forEach(orderProduct -> {
                 //Todo 재고 증가 로직
+                Product product = productRepository.findByIdWithPessimisticLock(orderProduct.getProduct().getId())
+                        .orElseThrow(() -> new BusinessException(PRODUCT_NOT_FOUND, "상품을 찾을 수 없습니다. ID: " + orderProduct.getProduct().getId()));
+
+                product.increaseStock(orderProduct.getQuantity());
+                productRepository.saveAndFlush(product);
+
                 // Product 엔티티에 추가한 addStock 호출
 //                orderProduct.getProduct().addStock(orderProduct.getQuantity());
             });

--- a/src/main/java/com/team10/backend/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductQueryController.java
@@ -30,13 +30,13 @@ public class ProductQueryController {
     @Operation(summary = "상품 전체 조회",
             description = "등록된 상품 목록을 최신순으로 조회하며, 페이지 및 필터 조건을 지원합니다.")
     public ApiResponse<ProductPageResponse> list(
-            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
+            @RequestParam(defaultValue = "1") @Min(value = 1, message = "page는 1 이상이어야 합니다.") int page,
             @RequestParam(defaultValue = "10") @Min(value = 1, message = "size는 1 이상이어야 합니다.") int size,
             @RequestParam(required = false) ProductType type,
             @RequestParam(required = false) ProductStatus status,
             @RequestParam(required = false) Long sellerId
     ) {
-        ProductPageResponse response = productService.list(page, size, type, status, sellerId);
+        ProductPageResponse response = productService.list(page - 1, size, type, status, sellerId);
         return ApiResponse.ok(response);
     }
 

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductDetailResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductDetailResponse.java
@@ -10,6 +10,7 @@ public record ProductDetailResponse(
         String description,
         int price,
         int stock,
+        String nickname,
         String imageUrl,
         ProductType type,
         ProductStatus status
@@ -21,6 +22,7 @@ public record ProductDetailResponse(
                 product.getDescription(),
                 product.getPrice(),
                 product.getStock(),
+                product.getUser().getNickname(),
                 product.getImageUrl(),
                 product.getType(),
                 product.getStatus()

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductListResponse.java
@@ -8,16 +8,19 @@ public record ProductListResponse(
         Long productId,
         String productName,
         int price,
+        String nickname,
         String imageUrl,
         ProductType type,
         ProductStatus status,
         Long sellerId
+
 ) {
     public static ProductListResponse from(Product product) {
         return new ProductListResponse(
                 product.getId(),
                 product.getProductName(),
                 product.getPrice(),
+                product.getUser().getNickname(),
                 product.getImageUrl(),
                 product.getType(),
                 product.getStatus(),

--- a/src/main/java/com/team10/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/team10/backend/domain/product/service/ProductService.java
@@ -93,7 +93,7 @@ public class ProductService {
 
         return new ProductPageResponse(
                 content,
-                productPage.getNumber(),
+                productPage.getNumber() + 1,
                 productPage.getSize(),
                 productPage.getTotalElements(),
                 productPage.getTotalPages()

--- a/src/test/java/com/team10/backend/domain/order/controller/OrderDeleteControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/order/controller/OrderDeleteControllerTest.java
@@ -1,7 +1,6 @@
 package com.team10.backend.domain.order.controller;
 
 import com.team10.backend.global.exception.ErrorCode;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,12 +8,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.persistence.EntityManager;
+import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -37,7 +36,7 @@ public class OrderDeleteControllerTest {
     void deleteOrder_Success() throws Exception {
         // 1. 유저 및 상품 세팅
         jdbcTemplate.update("INSERT INTO users (id, email, password, name, nickname, phone_number, address, user_status, role) VALUES (1, 'buyer@test.com', '1', '구매자', '구매자', '010', '서울', 'ACTIVE', 'BUYER')");
-        jdbcTemplate.update("INSERT INTO products (id, user_id, product_name, price, stock, type, status) VALUES (101, 1, '상품', 10000, 10, 'BOOK', 'SELLING')");
+        jdbcTemplate.update("INSERT INTO products (id, user_id, product_name, price, stock, type, status) VALUES (101, 1, '상품', 10000, 9, 'BOOK', 'SELLING')");
 
         // 2. 주문 세팅 (READY 상태)
         String orderNum = "ORD-DELETE-001";
@@ -53,6 +52,15 @@ public class OrderDeleteControllerTest {
                 .andDo(print());
 
         // [참고] 환불/재고 로직이 추가되면 여기서 jdbcTemplate으로 재고가 늘어났는지 확인하는 로직을 추가할 예정
+        Integer restoredStock = jdbcTemplate.queryForObject(
+                "SELECT stock FROM products WHERE id = ?", Integer.class, 101L);
+
+        assertEquals(Integer.valueOf(10), restoredStock);
+
+        Map<String, Object> deletedOrder = jdbcTemplate.queryForMap(
+                "SELECT * FROM orders WHERE order_number = ?", orderNum);
+
+        assertEquals(Boolean.TRUE, deletedOrder.get("is_deleted"));
     }
 
     @Test

--- a/src/test/java/com/team10/backend/domain/order/service/OrderConcurrencyTest.java
+++ b/src/test/java/com/team10/backend/domain/order/service/OrderConcurrencyTest.java
@@ -1,0 +1,143 @@
+package com.team10.backend.domain.order.service;
+
+import com.team10.backend.domain.order.dto.OrderCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class OrderConcurrencyTest {
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", () ->
+                "jdbc:h2:mem:order_concurrency_" + UUID.randomUUID()
+                        + ";MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        registry.add("spring.datasource.username", () -> "sa");
+        registry.add("spring.datasource.password", () -> "");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    }
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("동시 주문 - 재고가 1개 남은 상품은 2명 중 1명만 주문 성공")
+    void t2() throws Exception {
+        jdbcTemplate.update("DELETE FROM payments");
+        jdbcTemplate.update("DELETE FROM order_products");
+        jdbcTemplate.update("DELETE FROM order_delivery");
+        jdbcTemplate.update("DELETE FROM orders");
+        jdbcTemplate.update("DELETE FROM products");
+        jdbcTemplate.update("DELETE FROM users");
+
+        jdbcTemplate.update(
+                "INSERT INTO users (id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                1L, "user1@test.com", "1234", "구매자1", "u1", "010-1111-1111", "서울", "ACTIVE", "BUYER"
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO users (id, email, password, name, nickname, phone_number, address, user_status, role, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                2L, "user2@test.com", "1234", "구매자2", "u2", "010-2222-2222", "대전", "ACTIVE", "BUYER"
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO products (id, user_id, product_name, price, stock, type, status, created_at, updated_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                201L, 1L, "자바스프링", 10000, 1, "BOOK", "SELLING"
+        );
+
+        // 201번 상품 1개 주문 데이터
+        OrderCreateRequest.OrderProductReq item = new OrderCreateRequest.OrderProductReq(201L, 1);
+
+        // 유저별 주문 요청
+        OrderCreateRequest req1 = new OrderCreateRequest(1L, "서울시", List.of(item));
+        OrderCreateRequest req2 = new OrderCreateRequest(2L, "대전시", List.of(item));
+
+        // 스레드 2개 생성
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        // 동시 시작 제어
+        CountDownLatch readyLatch = new CountDownLatch(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        // 성공/실패 횟수(기대값 성공 1, 실패 1)
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // 동시 주문 작업을 각 스레드에 등록
+        Future<?> future1 = executorService.submit(() -> {
+            readyLatch.countDown();
+            try {
+                startLatch.await();
+                orderService.createOrder(req1);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            }
+        });
+
+        Future<?> future2 = executorService.submit(() -> {
+            readyLatch.countDown();
+            try {
+                startLatch.await();
+                orderService.createOrder(req2);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            }
+        });
+
+        // 두 스레드가 모두 시작 준비를 마칠 때까지 대기
+        readyLatch.await();
+        // 두 스레드에 동시에 시작 신호 전달
+        startLatch.countDown();
+
+        // 두 주문 작업이 모두 끝날 때까지 대기
+        future1.get();
+        future2.get();
+        // 스레드 종료
+        executorService.shutdown();
+
+        // 최종 재고 조회
+        Integer remainStock = jdbcTemplate.queryForObject(
+                "SELECT stock FROM products WHERE id = ?",
+                Integer.class,
+                201L
+        );
+
+        // 최종 주문수 조회
+        Integer orderCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM orders",
+                Integer.class
+        );
+
+        assertThat(successCount.get()).isEqualTo(1); // 1명 성공
+        assertThat(failCount.get()).isEqualTo(1);    // 1명 실패
+        assertThat(remainStock).isEqualTo(0);        // 재고수
+        assertThat(orderCount).isEqualTo(1);         // 주문수
+    }
+}

--- a/src/test/java/com/team10/backend/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/order/service/OrderServiceTest.java
@@ -2,6 +2,7 @@ package com.team10.backend.domain.order.service;
 
 import com.team10.backend.domain.order.dto.OrderCreateRequest;
 import com.team10.backend.domain.order.dto.OrderResponse;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,9 @@ public class OrderServiceTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private EntityManager entityManager;
 
     @BeforeEach
     void setUp() {
@@ -73,6 +77,9 @@ public class OrderServiceTest {
         // When
         OrderResponse response = orderService.createOrder(req);
 
+        entityManager.flush();
+        entityManager.clear();
+
         // Then 1: 응답 데이터 검증
         assertThat(response.userId()).isEqualTo(1L);
         assertThat(response.totalAmount()).isEqualTo(2100000); // 총 합계 210만 원
@@ -102,5 +109,13 @@ public class OrderServiceTest {
         // Enum 값 비교 시 DB 저장 형태(String)에 맞춰 대문자로 확인
         assertThat(savedPayment.get("status").toString()).isEqualTo("READY");
         assertThat(((Number) savedPayment.get("total_amount")).intValue()).isEqualTo(2100000);
+
+        Integer stock101 = jdbcTemplate.queryForObject(
+                "SELECT stock FROM products WHERE id = ?", Integer.class, 101L);
+        Integer stock102 = jdbcTemplate.queryForObject(
+                "SELECT stock FROM products WHERE id = ?", Integer.class, 102L);
+
+        assertThat(stock101).isEqualTo(9);
+        assertThat(stock102).isEqualTo(18);
     }
 }

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
@@ -1,6 +1,5 @@
 package com.team10.backend.domain.product.controller;
 
-import tools.jackson.databind.ObjectMapper;
 import com.team10.backend.domain.product.dto.ProductStockRequest;
 import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.entity.Product;
@@ -18,19 +17,22 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Transactional
 class ProductCommandControllerTest {
 
     @Autowired

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductQueryControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductQueryControllerTest.java
@@ -24,12 +24,12 @@ class ProductQueryControllerTest {
     @DisplayName("상품 전체 조회 성공")
     void listProducts_success() throws Exception {
         mockMvc.perform(get("/api/v1/products")
-                        .param("page", "0")
+                        .param("page", "1")
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.content").isArray())
-                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.page").value(1))
                 .andExpect(jsonPath("$.data.size").value(10));
     }
 
@@ -37,7 +37,7 @@ class ProductQueryControllerTest {
     @DisplayName("상품 전체 조회 시, type 필터 적용 성공")
     void listProducts_withTypeFilter_success() throws Exception {
         mockMvc.perform(get("/api/v1/products")
-                        .param("page", "0")
+                        .param("page", "1")
                         .param("size", "10")
                         .param("type", "BOOK"))
                 .andExpect(status().isOk())
@@ -49,7 +49,7 @@ class ProductQueryControllerTest {
     @DisplayName("상품 전체 조회 시, status 필터 적용 성공")
     void listProducts_withStatusFilter_success() throws Exception {
         mockMvc.perform(get("/api/v1/products")
-                        .param("page", "0")
+                        .param("page", "1")
                         .param("size", "10")
                         .param("status", "SELLING"))
                 .andExpect(status().isOk())
@@ -61,7 +61,7 @@ class ProductQueryControllerTest {
     @DisplayName("상품 전체 조회 시, type/status 필터 적용 성공")
     void listProducts_withTypeAndStatusFilter_success() throws Exception {
         mockMvc.perform(get("/api/v1/products")
-                        .param("page", "0")
+                        .param("page", "1")
                         .param("size", "10")
                         .param("type", "BOOK")
                         .param("status", "SELLING"))

--- a/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/product/service/ProductServiceTest.java
@@ -145,7 +145,8 @@ class ProductServiceTest {
         ProductPageResponse response = productService.list(0, 10, null, null, null);
 
         assertThat(response.content()).hasSize(2);
-        assertThat(response.page()).isEqualTo(0);
+        assertThat(response.content().get(0).nickname()).isEqualTo("seller1");
+        assertThat(response.page()).isEqualTo(1);
         assertThat(response.size()).isEqualTo(10);
         assertThat(response.totalElements()).isEqualTo(2);
         assertThat(response.totalPages()).isEqualTo(1);
@@ -162,6 +163,7 @@ class ProductServiceTest {
         ProductPageResponse response = productService.list(0, 10, ProductType.BOOK, null, null);
 
         assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).nickname()).isEqualTo("seller1");
         assertThat(response.content().get(0).productName()).isEqualTo("책1");
         assertThat(response.content().get(0).type()).isEqualTo(ProductType.BOOK);
     }
@@ -180,6 +182,7 @@ class ProductServiceTest {
         ProductPageResponse response = productService.list(0, 10, null, ProductStatus.SELLING, null);
 
         assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).nickname()).isEqualTo("seller1");
         assertThat(response.content().get(0).productName()).isEqualTo("책1");
         assertThat(response.content().get(0).status()).isEqualTo(ProductStatus.SELLING);
     }
@@ -200,6 +203,7 @@ class ProductServiceTest {
         ProductPageResponse response = productService.list(0, 10, ProductType.BOOK, ProductStatus.SELLING, null);
 
         assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).nickname()).isEqualTo("seller1");
         assertThat(response.content().get(0).productName()).isEqualTo("책1");
         assertThat(response.content().get(0).type()).isEqualTo(ProductType.BOOK);
         assertThat(response.content().get(0).status()).isEqualTo(ProductStatus.SELLING);
@@ -225,6 +229,7 @@ class ProductServiceTest {
         assertThat(response.productId()).isEqualTo(savedProduct.getId());
         assertThat(response.productName()).isEqualTo("ABC");
         assertThat(response.description()).isEqualTo("책 설명입니다.");
+        assertThat(response.nickname()).isEqualTo("seller1");
         assertThat(response.price()).isEqualTo(10000);
         assertThat(response.stock()).isEqualTo(100);
         assertThat(response.type()).isEqualTo(ProductType.BOOK);


### PR DESCRIPTION
## 📌 개요 (What)
주문 생성 시 재고 차감 로직에 비관적 락을 적용 및 주문 취소 시 재고 복구 로직을 반영했습니다.

## ✨ 작업 내용
- 주문 생성 시 상품 조회에 비관적 락 적용
- 주문 생성 시 재고 차감 로직 추가
- 주문 취소 시 재고 복구 로직 추가
- 주문 취소 관련 테스트 보완
- 동시 주문 상황 검증을 위한 테스트 코드 추가
- H2 환경에서 동시성 동작 검증
- JMeter를 이용한 동시 요청 테스트 진행 및 결과 확인

## 🔥 변경 이유

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

## 🔗 관련 이슈
- close #68 

## 📸 테스트
- 재고가 1인 상품을 동시에 2개의 주문 요청
<img width="1304" height="425" alt="1성공" src="https://github.com/user-attachments/assets/7e6ca87f-df15-4790-b4fc-e5f29a9a46f1" />
<br><br>
<img width="1304" height="425" alt="1실패" src="https://github.com/user-attachments/assets/80aa6db6-8a79-419d-8d2c-24506682dc11" />
<br><br>
- 하나의 주문만 성공
<img width="767" height="608" alt="DB결과" src="https://github.com/user-attachments/assets/86e971f1-a641-4651-9e1b-824f4070df73" />

