### PR TITLE
refactor: @AuthenticationPrincipal 기반 상품 관리 API 인증 처리

### DIFF
--- a/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
+++ b/src/main/java/com/team10/backend/domain/product/controller/ProductCommandController.java
@@ -8,12 +8,13 @@ import com.team10.backend.domain.product.dto.ProductStockResponse;
 import com.team10.backend.domain.product.dto.ProductUpdateRequest;
 import com.team10.backend.domain.product.service.ProductService;
 import com.team10.backend.global.dto.ApiResponse;
+import com.team10.backend.global.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,41 +36,38 @@ public class ProductCommandController {
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "상품 등록", description = "판매자가 신규 상품을 등록합니다.")
     public ApiResponse<ProductDetailResponse> create(
-            @RequestBody @Valid ProductCreateRequest request,
-            Authentication authentication) {
-        Long userId = Long.parseLong(authentication.getName());
-        return ApiResponse.ok(productService.create(userId, request));
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @RequestBody @Valid ProductCreateRequest request
+    ) {
+        return ApiResponse.ok(productService.create(principal.userId(), request));
     }
 
     @PutMapping("/{productId}")
     @Operation(summary = "상품 수정", description = "판매자가 등록한 상품 정보를 수정합니다.")
     public ApiResponse<ProductDetailResponse> update(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long productId,
-            @RequestBody @Valid ProductUpdateRequest request,
-            Authentication authentication
+            @RequestBody @Valid ProductUpdateRequest request
     ) {
-        Long userId = Long.parseLong(authentication.getName());
-        return ApiResponse.ok(productService.update(userId, productId, request));
+        return ApiResponse.ok(productService.update(principal.userId(), productId, request));
     }
 
     @PatchMapping("/{productId}/inactive")
     @Operation(summary = "상품 삭제(비활성화)", description = "판매자가 등록한 상품을 삭제합니다.")
     public ApiResponse<ProductInactiveResponse> inactive(
-            @PathVariable Long productId,
-            Authentication authentication
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long productId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
-        return ApiResponse.ok(productService.inactive(userId, productId));
+        return ApiResponse.ok(productService.inactive(principal.userId(), productId));
     }
 
     @PatchMapping("/{productId}/stock")
     @Operation(summary = "상품 재고 수정", description = "판매자가 등록한 상품의 재고를 수정합니다.")
     public ApiResponse<ProductStockResponse> updateStock(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long productId,
-            @RequestBody @Valid ProductStockRequest request,
-            Authentication authentication
+            @RequestBody @Valid ProductStockRequest request
     ) {
-        Long userId = Long.parseLong(authentication.getName());
-        return ApiResponse.ok(productService.updateStock(userId, productId, request));
+        return ApiResponse.ok(productService.updateStock(principal.userId(), productId, request));
     }
 }

--- a/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/product/controller/ProductCommandControllerTest.java
@@ -6,6 +6,8 @@ import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
 import com.team10.backend.domain.product.repository.ProductRepository;
+import com.team10.backend.domain.user.enums.Role;
+import com.team10.backend.global.security.CustomUserPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,15 +16,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -118,7 +123,6 @@ class ProductCommandControllerTest {
 
     @Test
     @DisplayName("BUYER 권한 사용자의 상품 등록 요청은 403")
-    @WithMockUser(username = "3", roles = "BUYER")
     void createProduct_fail_forbidden() throws Exception {
         String requestBody = """
                 {
@@ -131,6 +135,7 @@ class ProductCommandControllerTest {
                 """;
 
         mockMvc.perform(post("/api/v1/stores/me/products")
+                        .with(authenticatedUser(3L, Role.BUYER))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isForbidden());
@@ -138,7 +143,6 @@ class ProductCommandControllerTest {
 
     @Test
     @DisplayName("상품 등록 성공")
-    @WithMockUser(username = "1", roles = "SELLER")
     void createProduct_success() throws Exception {
         String requestBody = """
                 {
@@ -151,6 +155,7 @@ class ProductCommandControllerTest {
                 """;
 
         mockMvc.perform(post("/api/v1/stores/me/products")
+                        .with(authenticatedUser(1L, Role.SELLER))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isCreated())
@@ -178,7 +183,6 @@ class ProductCommandControllerTest {
 
     @Test
     @DisplayName("상품 수정 성공")
-    @WithMockUser(username = "1", roles = "SELLER")
     void updateProduct_success() throws Exception {
         jdbcTemplate.update(
                 "INSERT INTO products " +
@@ -205,6 +209,7 @@ class ProductCommandControllerTest {
         );
 
         mockMvc.perform(put("/api/v1/stores/me/products/{productId}", 1L)
+                        .with(authenticatedUser(1L, Role.SELLER))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -230,7 +235,6 @@ class ProductCommandControllerTest {
 
     @Test
     @DisplayName("본인 상품이 아닌 상품 수정 요청은 403")
-    @WithMockUser(username = "2", roles = "SELLER")
     void updateProduct_fail_accessDenied() throws Exception {
         jdbcTemplate.update(
                 "INSERT INTO products " +
@@ -257,6 +261,7 @@ class ProductCommandControllerTest {
         );
 
         mockMvc.perform(put("/api/v1/stores/me/products/{productId}", 1L)
+                        .with(authenticatedUser(2L, Role.SELLER))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isForbidden())
@@ -265,7 +270,6 @@ class ProductCommandControllerTest {
 
     @Test
     @DisplayName("상품 비활성화 성공")
-    @WithMockUser(username = "1", roles = "SELLER")
     void inactiveProduct_success() throws Exception {
         jdbcTemplate.update(
                 "INSERT INTO products " +
@@ -282,7 +286,8 @@ class ProductCommandControllerTest {
                 "SELLING"
         );
 
-        mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/inactive", 1L))
+        mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/inactive", 1L)
+                        .with(authenticatedUser(1L, Role.SELLER)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.productId").value(1))
@@ -295,7 +300,6 @@ class ProductCommandControllerTest {
 
     @Test
     @DisplayName("이미 비활성화된 상품 재요청 시 409")
-    @WithMockUser(username = "1", roles = "SELLER")
     void inactiveProduct_fail_alreadyInactive() throws Exception {
         jdbcTemplate.update(
                 "INSERT INTO products " +
@@ -312,13 +316,13 @@ class ProductCommandControllerTest {
                 "INACTIVE"
         );
 
-        mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/inactive", 1L))
+        mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/inactive", 1L)
+                        .with(authenticatedUser(1L, Role.SELLER)))
                 .andExpect(status().isConflict());
     }
 
     @Test
     @DisplayName("재고 수정 성공")
-    @WithMockUser(username = "1", roles = "SELLER")
     void updateStock_success() throws Exception {
         jdbcTemplate.update(
                 "INSERT INTO products " +
@@ -338,6 +342,7 @@ class ProductCommandControllerTest {
         ProductStockRequest request = new ProductStockRequest(30);
 
         mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/stock", 1L)
+                        .with(authenticatedUser(1L, Role.SELLER))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -349,14 +354,24 @@ class ProductCommandControllerTest {
 
     @Test
     @DisplayName("재고를 음수로 수정하면 검증 실패")
-    @WithMockUser(username = "1", roles = "SELLER")
     void updateStock_fail_negativeStock() throws Exception {
         ProductStockRequest request = new ProductStockRequest(-1);
 
         mockMvc.perform(patch("/api/v1/stores/me/products/{productId}/stock", 1L)
+                        .with(authenticatedUser(1L, Role.SELLER))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("VALIDATION_FAILED"));
+    }
+
+    private RequestPostProcessor authenticatedUser(Long userId, Role role) {
+        return authentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CustomUserPrincipal(userId, role),
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
+                )
+        );
     }
 }


### PR DESCRIPTION
## 📌 개요 (What)
@AuthenticationPrincipal CustomUserPrincipal을 사용하도록 변경했습니다.

## ✨ 작업 내용
- 상품 등록/수정/비활성화/재고수정 API에 @AuthenticationPrincipal CustomUserPrincipal 적용

## 🔥 변경 이유
인증 객체에서 사용자 정보를 직접 꺼내도록 변경했습니다.

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

## 🔗 관련 이슈
- close #
