### PR TITLE
fix: 등록/수정일 필드 추가

### DIFF
--- a/src/main/java/com/team10/backend/domain/product/dto/ProductDetailResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductDetailResponse.java
@@ -4,6 +4,8 @@ import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
 
+import java.time.LocalDateTime;
+
 public record ProductDetailResponse(
         Long productId,
         String productName,
@@ -13,7 +15,9 @@ public record ProductDetailResponse(
         String nickname,
         String imageUrl,
         ProductType type,
-        ProductStatus status
+        ProductStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
     public static ProductDetailResponse from(Product product) {
         return new ProductDetailResponse(
@@ -25,7 +29,9 @@ public record ProductDetailResponse(
                 product.getUser().getNickname(),
                 product.getImageUrl(),
                 product.getType(),
-                product.getStatus()
+                product.getStatus(),
+                product.getCreatedAt(),
+                product.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/team10/backend/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/com/team10/backend/domain/product/dto/ProductListResponse.java
@@ -4,6 +4,8 @@ import com.team10.backend.domain.product.entity.Product;
 import com.team10.backend.domain.product.enums.ProductStatus;
 import com.team10.backend.domain.product.enums.ProductType;
 
+import java.time.LocalDateTime;
+
 public record ProductListResponse(
         Long productId,
         String productName,
@@ -12,8 +14,9 @@ public record ProductListResponse(
         String imageUrl,
         ProductType type,
         ProductStatus status,
-        Long sellerId
-
+        Long sellerId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
     public static ProductListResponse from(Product product) {
         return new ProductListResponse(
@@ -24,7 +27,9 @@ public record ProductListResponse(
                 product.getImageUrl(),
                 product.getType(),
                 product.getStatus(),
-                product.getUser().getId()
+                product.getUser().getId(),
+                product.getCreatedAt(),
+                product.getUpdatedAt()
         );
     }
 }


### PR DESCRIPTION
## 📌 개요 (What)
상품 응답에 등록일, 수정일 필드를 추가했습니다.

## ✨ 작업 내용
상품 조회 응답 DTO에 createdAt, updatedAt 필드 추가

## 🔥 변경 이유
프론트엔드에서 상품 등록일과 수정일 표시가 필요해서 반영했습니다.

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [x] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

## 🔗 관련 이슈
- close #
