### PR TITLE
refactor: 피드 이미지 단일로 수정

### DIFF
--- a/src/main/java/com/team10/backend/domain/feed/dto/post/CreateFeedRequestDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/post/CreateFeedRequestDto.java
@@ -3,14 +3,11 @@ package com.team10.backend.domain.feed.dto.post;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-import java.util.List;
-
 public record CreateFeedRequestDto(
         @NotBlank(message = "피드 내용은 필수입니다.")
         @Size(min = 1, max = 2000, message = "내용은 1자 이상 2,000자 이하로 입력해주세요.")
         String content,
 
-        @Size(max = 10, message = "미디어 파일은 최대 10개까지 업로드 가능합니다.")
-        List<String> mediaUrls
+        String imageUrl
 ) {
 }

--- a/src/main/java/com/team10/backend/domain/feed/dto/post/CreateFeedResponseDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/post/CreateFeedResponseDto.java
@@ -2,19 +2,17 @@ package com.team10.backend.domain.feed.dto.post;
 
 import com.team10.backend.domain.feed.entity.FeedPost;
 
-import java.util.List;
-
 public record CreateFeedResponseDto(
         Long feedId,
         String content,
-        List<String> mediaUrls,
+        String imageUrl,
         String createdAt
 ) {
     public static CreateFeedResponseDto from(FeedPost feedPost) {
         return new CreateFeedResponseDto(
                 feedPost.getId(),
                 feedPost.getContent(),
-                feedPost.getImageUrl() != null ? List.of(feedPost.getImageUrl()) : List.of(),
+                feedPost.getImageUrl(),
                 feedPost.getCreatedAt().toString()
         );
     }

--- a/src/main/java/com/team10/backend/domain/feed/dto/post/FeedResponseDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/post/FeedResponseDto.java
@@ -2,21 +2,17 @@ package com.team10.backend.domain.feed.dto.post;
 
 import com.team10.backend.domain.feed.entity.FeedPost;
 
-import java.util.List;
-
 public record FeedResponseDto(
         Long feedId,
         String content,
-        List<String> mediaUrls,
+        String imageUrl,
         String createdAt
 ) {
     public static FeedResponseDto from(FeedPost feedPost) {
         return new FeedResponseDto(
                 feedPost.getId(),
                 feedPost.getContent(),
-                feedPost.getImageUrl() != null && !feedPost.getImageUrl().isBlank()
-                        ? List.of(feedPost.getImageUrl())
-                        : List.of(),
+                feedPost.getImageUrl(),
                 feedPost.getCreatedAt().toString()
         );
     }

--- a/src/main/java/com/team10/backend/domain/feed/dto/post/UpdateFeedRequestDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/post/UpdateFeedRequestDto.java
@@ -3,14 +3,11 @@ package com.team10.backend.domain.feed.dto.post;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-import java.util.List;
-
 public record UpdateFeedRequestDto(
         @NotBlank(message = "피드 내용은 필수입니다.")
         @Size(min = 1, max = 2000, message = "내용은 1자 이상 2,000자 이하로 입력해주세요.")
         String content,
 
-        @Size(max = 10, message = "미디어 파일은 최대 10개까지 업로드 가능합니다.")
-        List<String> mediaUrls
+        String imageUrl
 ) {
 }

--- a/src/main/java/com/team10/backend/domain/feed/dto/post/UpdateFeedResponseDto.java
+++ b/src/main/java/com/team10/backend/domain/feed/dto/post/UpdateFeedResponseDto.java
@@ -2,21 +2,17 @@ package com.team10.backend.domain.feed.dto.post;
 
 import com.team10.backend.domain.feed.entity.FeedPost;
 
-import java.util.List;
-
 public record UpdateFeedResponseDto(
         Long feedId,
         String content,
-        List<String> mediaUrls,
+        String imageUrl,
         String updatedAt
 ) {
     public static UpdateFeedResponseDto from(FeedPost feedPost) {
         return new UpdateFeedResponseDto(
                 feedPost.getId(),
                 feedPost.getContent(),
-                feedPost.getImageUrl() != null && !feedPost.getImageUrl().isBlank()
-                        ? List.of(feedPost.getImageUrl())
-                        : List.of(),
+                feedPost.getImageUrl(),
                 feedPost.getUpdatedAt().toString()
         );
     }

--- a/src/main/java/com/team10/backend/domain/feed/service/FeedPostService.java
+++ b/src/main/java/com/team10/backend/domain/feed/service/FeedPostService.java
@@ -60,7 +60,7 @@ public class FeedPostService {
         validateSeller(currentUser);
 
         FeedPost feedPost = new FeedPost(
-                extractThumbnailUrl(requestDto),
+                requestDto.imageUrl(),
                 requestDto.content(),
                 currentUser
         );
@@ -80,7 +80,7 @@ public class FeedPostService {
 
         String oldImageUrl = feedPost.getImageUrl();
 
-        String newImageUrl = extractThumbnailUrl(requestDto);
+        String newImageUrl = requestDto.imageUrl();
 
         if (!Objects.equals(oldImageUrl, newImageUrl)) {
             imageUploadService.deleteIfManaged(oldImageUrl);
@@ -155,20 +155,6 @@ public class FeedPostService {
         if (user.getRole() != Role.SELLER) {
             throw new BusinessException(ErrorCode.ACCESS_DENIED);
         }
-    }
-
-    // 멀티 이미지 요청이 와도 대표 이미지로 첫 번째 URL만 사용한다.
-    private String extractThumbnailUrl(CreateFeedRequestDto requestDto) {
-        return requestDto.mediaUrls() != null && !requestDto.mediaUrls().isEmpty()
-                ? requestDto.mediaUrls().getFirst()
-                : null;
-    }
-
-    // 수정 요청에서도 대표 이미지로 첫 번째 URL만 사용한다.
-    private String extractThumbnailUrl(UpdateFeedRequestDto requestDto) {
-        return requestDto.mediaUrls() != null && !requestDto.mediaUrls().isEmpty()
-                ? requestDto.mediaUrls().getFirst()
-                : null;
     }
 
     // 현재 로그인 사용자의 좋아요 여부를 포함해 FeedDto로 변환한다.

--- a/src/test/java/com/team10/backend/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/team10/backend/domain/feed/controller/FeedControllerTest.java
@@ -88,7 +88,7 @@ public class FeedControllerTest {
         String requestBody = """
             {
               "content": "오늘의 새로운 소식!",
-              "mediaUrls": ["https://image.url/1"]
+              "imageUrl": "https://image.url/1"
             }
             """;
 
@@ -98,7 +98,7 @@ public class FeedControllerTest {
                         .content(requestBody))
                 .andExpect(status().isCreated()) // 201 확인
                 .andExpect(jsonPath("$.data.content").value("오늘의 새로운 소식!"))
-                .andExpect(jsonPath("$.data.mediaUrls[0]").value("https://image.url/1"));
+                .andExpect(jsonPath("$.data.imageUrl").value("https://image.url/1"));
 
         assertThat(feedPostRepository.findAll().getFirst().getImageUrl())
                 .isEqualTo("https://image.url/1");
@@ -109,8 +109,7 @@ public class FeedControllerTest {
     void createFeed_withoutImageUrl() throws Exception {
         String requestBody = """
             {
-              "content": "이미지 없는 소식!",
-              "mediaUrls": []
+              "content": "이미지 없는 소식!"
             }
             """;
 
@@ -120,7 +119,7 @@ public class FeedControllerTest {
                         .content(requestBody))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.content").value("이미지 없는 소식!"))
-                .andExpect(jsonPath("$.data.mediaUrls").isEmpty());
+                .andExpect(jsonPath("$.data.imageUrl").isEmpty());
 
         assertThat(feedPostRepository.findAll().getFirst().getImageUrl()).isNull();
     }
@@ -174,7 +173,7 @@ public class FeedControllerTest {
         String requestBody = """
             {
               "content": "수정된 피드입니다",
-              "mediaUrls": ["https://test.com/new-image.jpg"]
+              "imageUrl": "https://test.com/new-image.jpg"
             }
             """;
 
@@ -186,7 +185,7 @@ public class FeedControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.feedId").value(100))
                 .andExpect(jsonPath("$.data.content").value("수정된 피드입니다"))
-                .andExpect(jsonPath("$.data.mediaUrls[0]").value("https://test.com/new-image.jpg"));
+                .andExpect(jsonPath("$.data.imageUrl").value("https://test.com/new-image.jpg"));
     }
 
     @Test

--- a/src/test/java/com/team10/backend/domain/feed/service/FeedPostServiceTest.java
+++ b/src/test/java/com/team10/backend/domain/feed/service/FeedPostServiceTest.java
@@ -22,8 +22,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -131,7 +129,7 @@ public class FeedPostServiceTest {
 
         CreateFeedRequestDto requestDto = new CreateFeedRequestDto(
                 "테스트 피드 내용입니다.",
-                List.of("https://test-image.com")
+                "https://test-image.com"
         );
 
 
@@ -140,7 +138,7 @@ public class FeedPostServiceTest {
 
         assertThat(result.feedId()).isNotNull();
         assertThat(result.content()).isEqualTo("테스트 피드 내용입니다.");
-        assertThat(result.mediaUrls().get(0)).isEqualTo("https://test-image.com");
+        assertThat(result.imageUrl()).isEqualTo("https://test-image.com");
         assertThat(feedPostRepository.count()).isEqualTo(1);
     }
 
@@ -160,14 +158,14 @@ public class FeedPostServiceTest {
 
         UpdateFeedRequestDto requestDto = new UpdateFeedRequestDto(
                 "수정된 피드입니다",
-                List.of("https://test.com/new-image.jpg")
+                "https://test.com/new-image.jpg"
         );
 
         UpdateFeedResponseDto result = feedPostService.updateFeed(100L, requestDto, testUser.getId());
 
         assertThat(result.feedId()).isEqualTo(100L);
         assertThat(result.content()).isEqualTo("수정된 피드입니다");
-        assertThat(result.mediaUrls()).containsExactly("https://test.com/new-image.jpg");
+        assertThat(result.imageUrl()).isEqualTo("https://test.com/new-image.jpg");
 
         var updatedFeed = feedPostRepository.findById(100L).orElseThrow();
         assertThat(updatedFeed.getContent()).isEqualTo("수정된 피드입니다");
@@ -190,7 +188,7 @@ public class FeedPostServiceTest {
 
         UpdateFeedRequestDto requestDto = new UpdateFeedRequestDto(
                 "권한 없는 수정입니다",
-                List.of("https://test.com/new-image.jpg")
+                "https://test.com/new-image.jpg"
         );
 
         assertThatThrownBy(() -> feedPostService.updateFeed(101L, requestDto, buyerUser.getId()))


### PR DESCRIPTION
## 📌 개요 (What)
- 피드 이미지 단일로 수정

## ✨ 작업 내용
- 피드 이미지 단일로 수정

## 🔥 변경 이유
- 요청은 단일이미지인데 응답은 리스트형태여서 오류발생으로 인한 수정

## 🧪 테스트
- [ ] 기능 정상 동작 확인
- [ ] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

## 🔗 관련 이슈
- close #
